### PR TITLE
Minimize chances of a blocker halfway through provisioning

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -6,7 +6,7 @@ name: 'Test and (Maybe) Release'
 on:
   push:
     branches:
-    - '**'
+    - 'refs/heads/main'
   pull_request:
 
 jobs:

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 packversion: 1
 name: eks-services-pack
-version: 1.0.0
+version: 0.6.0
 metadata:
   author: Bret Mogilefsky
 platforms:

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -207,7 +207,7 @@ module "aws_load_balancer_controller" {
   k8s_namespace             = "kube-system"
   aws_region_name           = data.aws_region.current.name
   k8s_cluster_name          = data.aws_eks_cluster.main.name
-  alb_controller_depends_on = [aws_eks_fargate_profile.default_namespaces, module.vpc, module.eks.cluster_id]
+  alb_controller_depends_on = [module.vpc, null_resource.coredns_restart_on_fargate]
 
 }
 

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -32,9 +32,31 @@ locals {
     "rbac.create"                                  = "true"
   }
 }
+
+# Confirm that the necessary CLI binaries are present
+resource "null_resource" "prerequisite_binaries_present" {
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOF
+      which aws-iam-authenticator git helm kubectl
+    EOF
+  }
+}
+
 resource "random_id" "cluster" {
   byte_length = 8
+
+  # If the necessary CLI binaries are not present, then we'll only get partway
+  # through provisioning before we are stopped cold as we try to use them,
+  # leaving everything in a poor state. We want to check for them as early as we
+  # can to avoid that. As this random_id is key to a bunch of other
+  # provisioning, we add an explicit dependency here to ensure the check for the
+  # binaries happens early.
+  depends_on = [
+    null_resource.prerequisite_binaries_present
+  ]
 }
+
 provider "aws" {
   # We need at least 3.16.0 because it fixes a problem with creating/deleting
   # Fargate profiles in parallel. See this issue for more information:


### PR DESCRIPTION
These commits resolve problems I've observed tripping up clean apply/destroy operations when the brokerpak was in use in a prod-like environment.