### PR TITLE
Fix ref to only include the branch name here

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -6,7 +6,7 @@ name: 'Test and (Maybe) Release'
 on:
   push:
     branches:
-    - 'refs/heads/main'
+    - 'main'
   pull_request:
 
 jobs:


### PR DESCRIPTION
Turns out it really only wants branch names, not refs here. Merging this will cause a new release to be cut as expected.