### PR TITLE
Ensure that k8s and helm providers are using a valid token

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 packversion: 1
 name: eks-services-pack
-version: 0.6.0
+version: 0.7.0
 metadata:
   author: Bret Mogilefsky
 platforms:

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -202,17 +202,25 @@ resource "aws_iam_openid_connect_provider" "cluster" {
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.main.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.main.token
   load_config_file       = false
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    args        = ["token", "--cluster-id", data.aws_eks_cluster.main.id]
+    command     = "aws-iam-authenticator"
+  }
 }
 
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.main.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
-    token                  = data.aws_eks_cluster_auth.main.token
     load_config_file       = false
     config_path            = "./kubeconfig_${module.eks.cluster_id}"
+    exec {
+      api_version = "client.authentication.k8s.io/v1alpha1"
+      args        = ["token", "--cluster-id", data.aws_eks_cluster.main.id]
+      command     = "aws-iam-authenticator"
+    }
   }
   # Helm 2.0.1 seems to have issues with alias. When alias is removed the helm_release provider working
   # Using Helm < 2.0.1 version seem to solve the issue.


### PR DESCRIPTION
Here's an example of the intermittent problem we're trying to resolve:
![image](https://user-images.githubusercontent.com/47762/106238099-18eb9800-61b5-11eb-8f08-a763669728e7.png)


Note this part of the error message in particular:
`Error: Kubernetes cluster unreachable: the server has asked for the client to provide credentials on .terraform/modules/instance.aws_load_balancer_controller/main.tf line 384, in resource "helm_release" "using_iamserviceaccount"`

My hypothesis is that the by the time the Fargate profile is set up and coredns has been fully restarted (which can take several minutes), the token generated via `data.aws_eks_cluster_auth.main` has expired. That expired token is then used to initialize the Helm provider when the first `helm_resource` is deployed, resulting in the error.

It turns out [there's documentation about this problem, and a facility for addressing it](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs#exec-based-credential-plugins). The PR here mimics [the provided example for EKS](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/_examples/eks/kubernetes-config/main.tf), but reuses the existing single-purpose `aws-iam-authenticator` binary rather than adding a new dependency on the more general `aws` CLI binary.
