### PR TITLE
Bind creates namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean: down ## Bring down the broker service if it's up and clean out the databa
 # Origin of the subdirectory dependency solution: 
 # https://stackoverflow.com/questions/14289513/makefile-rule-that-depends-on-all-files-under-a-directory-including-within-subd#comment19860124_14289872
 build: manifest.yml $(shell find services) ## Build the brokerpak(s)
-	docker run --rm $(DOCKER_OPTS) $(CSB) pak build
+	docker run $(DOCKER_OPTS) $(CSB) pak build
 
 # Healthcheck solution from https://stackoverflow.com/a/47722899 
 # (Alpine inclues wget, but not curl.)

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 packversion: 1
 name: eks-services-pack
-version: 0.7.0
+version: 0.10.0
 metadata:
   author: Bret Mogilefsky
 platforms:

--- a/services/eks-service-definition.yml
+++ b/services/eks-service-definition.yml
@@ -22,35 +22,34 @@ provision:
   computed_inputs: []
   outputs:
   - required: true
-    field_name: kubeconfig
+    field_name: cluster_id
     type: string
-    details: The kubeconfig to use when interacting with this instance
+    details: The name of the cluster that was provisioned
   template_ref: "services/terraform/eks-provision.tf"
 bind:
   plan_inputs: []
-  user_inputs: []
+  user_inputs:
+  - field_name: name
+    type: string
+    default: ""
+    required: false
+    details: "A name for the namespace to be created. Auto-generated if not supplied."
   computed_inputs:
-  - name: kubeconfig
-    default: ${instance.details["kubeconfig"]}
+  - name: cluster_id
+    default: ${instance.details["cluster_id"]}
     overwrite: true
     type: string
   outputs:
   - required: true
-    field_name: server
+    field_name: kubeconfig
     type: string
-    details: The service URL to provide when provisioning solr-cloud instances
-  - required: true
-    field_name: cluster_ca_certificate
-    type: string
-    details: Base64-encoded CA certificate to provide when provisioning solr-cloud instances
-  - required: true
-    field_name: token
-    type: string
-    details: Base64-encoded service account token to provide when provisioning solr-cloud instances 
+    details: A kubeconfig for administering the namespace
   template_ref: "services/terraform/eks-bind.tf"
 examples:
-- name: Example
-  description: Examples are used for documenting your service AND as integration tests.
+- name: Demonstrate provisioning and binding the "raw" plan
+  description: |
+    Provision an EKS cluster, then bind to get a kubeconfig
+    providing access to a namespace.
   plan_id: f921da02-d9b3-403d-b41f-223f2e61a861
   provision_params: {}
   bind_params: {}

--- a/services/terraform/eks-bind.tf
+++ b/services/terraform/eks-bind.tf
@@ -1,26 +1,108 @@
-variable "kubeconfig" { type = string }
+variable "cluster_id" { type = string }
+variable "name" { 
+  type = string 
+  default = ""
+}
+
+output "namespace" { value = kubernetes_namespace.binding.metadata[0].name }
+
 locals {
-  raw_data     = yamldecode(var.kubeconfig)
-  cluster_name = local.raw_data.clusters[0].name
-}
-output "cluster_ca_certificate" { value = local.raw_data.clusters[0].cluster.certificate-authority-data }
-output "server" { value = local.raw_data.clusters[0].cluster.server }
-output "token" { value = data.aws_eks_cluster_auth.instance.token }
-
-# Get a token for the cluster in question
-data "aws_eks_cluster_auth" "instance" {
-  name  = local.cluster_name
+  name        = var.name != "" ? var.name : "ns-${random_id.name.hex}"
 }
 
-# TODO: 
-# 1) Fire up the kubernetes provider
-# 2) Create a namespace
-# 3) Create a Fargate profile for that namespace
-# 4) Generate a role and secret with access to that namespace only (like in solroperator/operator-bind.tf)
+resource "random_id" "name" {
+  byte_length = 8
+}
 
-# provider "kubernetes" {
-#   host                   = var.server
-#   cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
-#   token                  = base64decode(var.token)
-#   load_config_file       = false
-# }
+provider "kubernetes" {
+  version = "~> 1.13.3"
+  host                   = data.aws_eks_cluster.main.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
+  load_config_file       = false
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    args        = ["token", "--cluster-id", data.aws_eks_cluster.main.id]
+    command     = "aws-iam-authenticator"
+  }
+}
+
+resource "kubernetes_namespace" "binding" {
+  metadata {
+    name = local.name
+    annotations = {}
+  }
+}
+
+data "aws_eks_cluster" "main" {
+  name  = var.cluster_id
+}
+
+data "aws_eks_cluster_auth" "main" {
+  name  = var.cluster_id
+}
+
+data "aws_iam_role" "iam_role_fargate" {
+  name = "eks-fargate-profile-${data.aws_eks_cluster.main.name}"
+}
+
+resource "aws_eks_fargate_profile" "binding" {
+  cluster_name           = data.aws_eks_cluster.main.name
+  fargate_profile_name   = kubernetes_namespace.binding.metadata[0].name
+  pod_execution_role_arn = data.aws_iam_role.iam_role_fargate.arn
+  subnet_ids             = data.aws_eks_cluster.main.vpc_config[0].subnet_ids
+  selector {
+    namespace = kubernetes_namespace.binding.metadata[0].name
+  }
+}
+
+# Create a service account for the namespace
+resource "kubernetes_service_account" "namespace_admin" {
+  metadata {
+    name = "admin"
+    namespace     = kubernetes_namespace.binding.metadata[0].name
+  }
+}
+
+
+# A namespace-level admin role
+resource "kubernetes_role" "namespace_admin" {
+  metadata {
+    name        = "namespace-admin"
+    namespace   = kubernetes_namespace.binding.metadata[0].name
+  }
+
+  rule {
+    api_groups = ["*"]
+    resources  = ["*"]
+    verbs      = ["*"]
+  }
+}
+
+# Bind the namespace-admin role to the service account
+resource "kubernetes_role_binding" "service_account_role_binding" {
+  metadata {
+    name      = "${kubernetes_service_account.namespace_admin.metadata[0].name}-admin-role-binding"
+    namespace = kubernetes_namespace.binding.metadata[0].name
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = "namespace-admin"
+  }
+
+  subject {
+    api_group = ""
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.namespace_admin.metadata[0].name
+    namespace = kubernetes_namespace.binding.metadata[0].name
+  }
+}
+
+# Read in the generated (default) secret for the service account
+data "kubernetes_secret" "secret" { 
+  metadata {
+    name = kubernetes_service_account.namespace_admin.default_secret_name
+    namespace = kubernetes_namespace.binding.metadata[0].name
+  }
+}

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -10,6 +10,7 @@
 #   https://medium.com/citihub/a-more-secure-way-to-call-kubectl-from-terraform-1052adf37af8
 
 output "kubeconfig" { value = module.eks.kubeconfig }
+output "cluster_id" { value = module.eks.cluster_id }
 
 locals {
   cluster_name    = "k8s-${random_id.cluster.hex}"
@@ -208,6 +209,7 @@ provider "kubernetes" {
     args        = ["token", "--cluster-id", data.aws_eks_cluster.main.id]
     command     = "aws-iam-authenticator"
   }
+  version = "~> 1.13.3"
 }
 
 provider "helm" {

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -9,7 +9,6 @@
 #   without spilling secrets into the logs comes from:
 #   https://medium.com/citihub/a-more-secure-way-to-call-kubectl-from-terraform-1052adf37af8
 
-output "kubeconfig" { value = module.eks.kubeconfig }
 output "cluster_id" { value = module.eks.cluster_id }
 
 locals {

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -306,8 +306,8 @@ data "aws_region" "current" {}
 
 # Use a convenient module to install the AWS Load Balancer controller
 module "aws_load_balancer_controller" {
-  source = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=v4.1.0"
   # source                    = "/local/path/to/terraform-kubernetes-aws-load-balancer-controller"
+  source = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=v4.1.0gsa"
   k8s_cluster_type          = "eks"
   k8s_namespace             = "kube-system"
   aws_region_name           = data.aws_region.current.name


### PR DESCRIPTION
When a provisioned cluster is bound, a namespace is created along with an "admin" service account with full permissions in that namespace. The binding output contains a kubeconfig suitable for working with that namespace via the service account.

Addresses https://github.com/GSA/eks-brokerpak/issues/5