### PR TITLE
Better naming and tagging

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 packversion: 1
 name: eks-services-pack
-version: 0.12.0
+version: 0.13.0
 metadata:
   author: Bret Mogilefsky
 platforms:

--- a/services/eks-service-definition.yml
+++ b/services/eks-service-definition.yml
@@ -19,7 +19,15 @@ plans:
   properties: {}
 provision:
   plan_inputs: []
-  computed_inputs: []
+  computed_inputs:
+  - name: instance_name
+    required: true
+    type: string
+    default: ${request.instance_id}
+  - name: labels
+    required: true
+    type: object
+    default: ${json.marshal(request.default_labels)}
   outputs:
   - field_name: cluster_id
     required: true

--- a/services/eks-service-definition.yml
+++ b/services/eks-service-definition.yml
@@ -21,8 +21,8 @@ provision:
   plan_inputs: []
   computed_inputs: []
   outputs:
-  - required: true
-    field_name: cluster_id
+  - field_name: cluster_id
+    required: true
     type: string
     details: The name of the cluster that was provisioned
   template_ref: "services/terraform/eks-provision.tf"
@@ -37,27 +37,28 @@ bind:
   computed_inputs:
   - name: cluster_id
     default: ${instance.details["cluster_id"]}
+    required: true
     overwrite: true
     type: string
   outputs:
-  - required: true
-    field_name: kubeconfig
+  - field_name: kubeconfig
+    required: true
     type: string
     details: A standalone kubeconfig for administering the created namespace
-  - required: true
-    field_name: server
+  - field_name: server
+    required: true
     type: string
     details: The kubernetes service endpoint
-  - required: true
-    field_name: token
+  - field_name: token
+    required: true
     type: string
     details: An authentication token for a service account in the namespace
-  - required: true
-    field_name: namespace
+  - field_name: namespace
+    required: true
     type: string
     details: The name of the namespace that was created
-  - required: true
-    field_name: certificate_authority_data
+  - field_name: certificate_authority_data
+    required: true
     type: string
     details: The CA data for the kubernetes endpoint
   template_ref: "services/terraform/eks-bind.tf"

--- a/services/eks-service-definition.yml
+++ b/services/eks-service-definition.yml
@@ -29,11 +29,6 @@ provision:
     default: ${json.marshal(request.default_labels)}
     overwrite: true
     type: object
-  outputs:
-  - field_name: cluster_id
-    required: true
-    type: string
-    details: The name of the cluster that was provisioned
   template_ref: "services/terraform/eks-provision.tf"
 bind:
   plan_inputs: []
@@ -43,8 +38,8 @@ bind:
     details: "A name for the namespace to be created. Auto-generated if not supplied."
     default: ${request.binding_id}
   computed_inputs:
-  - name: cluster_id
-    default: ${instance.details["cluster_id"]}
+  - name: instance_id
+    default: ${request.instance_id}
     required: true
     overwrite: true
     type: string

--- a/services/eks-service-definition.yml
+++ b/services/eks-service-definition.yml
@@ -19,15 +19,16 @@ plans:
   properties: {}
 provision:
   plan_inputs: []
+  user_inputs: []
   computed_inputs:
   - name: instance_name
     required: true
     type: string
     default: ${request.instance_id}
   - name: labels
-    required: true
-    type: object
     default: ${json.marshal(request.default_labels)}
+    overwrite: true
+    type: object
   outputs:
   - field_name: cluster_id
     required: true
@@ -39,9 +40,8 @@ bind:
   user_inputs:
   - field_name: name
     type: string
-    default: ""
-    required: false
     details: "A name for the namespace to be created. Auto-generated if not supplied."
+    default: ${request.binding_id}
   computed_inputs:
   - name: cluster_id
     default: ${instance.details["cluster_id"]}

--- a/services/eks-service-definition.yml
+++ b/services/eks-service-definition.yml
@@ -43,7 +43,23 @@ bind:
   - required: true
     field_name: kubeconfig
     type: string
-    details: A kubeconfig for administering the namespace
+    details: A standalone kubeconfig for administering the created namespace
+  - required: true
+    field_name: server
+    type: string
+    details: The kubernetes service endpoint
+  - required: true
+    field_name: token
+    type: string
+    details: An authentication token for a service account in the namespace
+  - required: true
+    field_name: namespace
+    type: string
+    details: The name of the namespace that was created
+  - required: true
+    field_name: certificate_authority_data
+    type: string
+    details: The CA data for the kubernetes endpoint
   template_ref: "services/terraform/eks-bind.tf"
 examples:
 - name: Demonstrate provisioning and binding the "raw" plan

--- a/services/terraform/eks-bind.tf
+++ b/services/terraform/eks-bind.tf
@@ -4,7 +4,12 @@ variable "name" {
   default = ""
 }
 
+
 output "kubeconfig" { value = data.template_file.kubeconfig.rendered }
+output "server" { value = data.aws_eks_cluster.main.endpoint }
+output "certificate_authority_data" { value = data.aws_eks_cluster.main.certificate_authority[0].data }
+output "token" { value = data.kubernetes_secret.secret.data.token}
+output "namespace" { value = kubernetes_namespace.binding.id}
 
 locals {
   name        = var.name != "" ? var.name : "ns-${random_id.name.hex}"

--- a/services/terraform/eks-bind.tf
+++ b/services/terraform/eks-bind.tf
@@ -1,4 +1,4 @@
-variable "cluster_id" { type = string }
+variable "instance_id" { type = string }
 variable "name" { type = string }
 
 
@@ -10,6 +10,7 @@ output "namespace" { value = kubernetes_namespace.binding.id}
 
 locals {
   name        = var.name != "" ? var.name : "ns-${random_id.name.hex}"
+  cluster_name = trim(var.instance_id,"- ")
 }
 
 resource "random_id" "name" {
@@ -36,11 +37,11 @@ resource "kubernetes_namespace" "binding" {
 }
 
 data "aws_eks_cluster" "main" {
-  name  = var.cluster_id
+  name  = local.cluster_name
 }
 
 data "aws_eks_cluster_auth" "main" {
-  name  = var.cluster_id
+  name  = local.cluster_name
 }
 
 data "aws_iam_role" "iam_role_fargate" {

--- a/services/terraform/eks-bind.tf
+++ b/services/terraform/eks-bind.tf
@@ -1,8 +1,5 @@
 variable "cluster_id" { type = string }
-variable "name" { 
-  type = string 
-  default = ""
-}
+variable "name" { type = string }
 
 
 output "kubeconfig" { value = data.template_file.kubeconfig.rendered }

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -103,15 +103,15 @@ module "eks" {
   source = "terraform-aws-modules/eks/aws"
   # version         = "13.2.1"
   # eks 13.2.1 has dependency for aws provider 3.16.0 so moving eks version to 12.1.0
-  version         = "12.1.0"
-  cluster_name    = local.cluster_name
-  cluster_version = local.cluster_version
-  vpc_id          = module.vpc.aws_vpc_id
-  subnets         = module.vpc.aws_subnet_private_prod_ids
-  cluster_enabled_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+  version                       = "12.1.0"
+  cluster_name                  = local.cluster_name
+  cluster_version               = local.cluster_version
+  vpc_id                        = module.vpc.aws_vpc_id
+  subnets                       = module.vpc.aws_subnet_private_prod_ids
+  cluster_enabled_log_types     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
   cluster_log_retention_in_days = 180
-  manage_aws_auth = false
-  write_kubeconfig = false
+  manage_aws_auth               = false
+  write_kubeconfig              = false
   tags                          = var.labels
 }
 
@@ -259,7 +259,7 @@ resource "null_resource" "namespace_fargate_logging" {
     environment = {
       KUBECONFIG = base64encode(module.eks.kubeconfig)
     }
-    command     = <<-EOF
+    command = <<-EOF
       kubectl --kubeconfig <(echo $KUBECONFIG | base64 -d) apply -f <(echo '${data.template_file.logging.rendered}') 
     EOF
   }
@@ -317,13 +317,12 @@ data "aws_region" "current" {}
 # Use a convenient module to install the AWS Load Balancer controller
 module "aws_load_balancer_controller" {
   # source                    = "/local/path/to/terraform-kubernetes-aws-load-balancer-controller"
-  source = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=v4.1.0gsa"
+  source                    = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=v4.1.0gsa"
   k8s_cluster_type          = "eks"
   k8s_namespace             = "kube-system"
   aws_region_name           = data.aws_region.current.name
   k8s_cluster_name          = data.aws_eks_cluster.main.name
-  alb_controller_depends_on = [module.vpc, null_resource.coredns_restart_on_fargate,null_resource.namespace_fargate_logging]
-
+  alb_controller_depends_on = [module.vpc, null_resource.coredns_restart_on_fargate, null_resource.namespace_fargate_logging]
   aws_tags                  = var.labels
 }
 

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -9,10 +9,17 @@
 #   without spilling secrets into the logs comes from:
 #   https://medium.com/citihub/a-more-secure-way-to-call-kubectl-from-terraform-1052adf37af8
 
-output "cluster_id" { value = module.eks.cluster_id }
+variable instance_name { 
+  type = string 
+  default = ""
+}
+variable labels {
+  type = map
+  default = {}
+}
 
 locals {
-  cluster_name    = "k8s-${random_id.cluster.hex}"
+  cluster_name    = var.instance_name != "" ? trim(var.instance_name, "- ") : "k8s-${random_id.cluster.hex}"
   cluster_version = "1.18"
   region          = "us-east-1"
   base_domain     = "ssb.datagov.us"
@@ -81,9 +88,9 @@ module "vpc" {
 
   # Tag subnets for use by AWS' load-balancers and the ALB ingress controllers
   # See https://aws.amazon.com/premiumsupport/knowledge-center/eks-vpc-subnet-discovery/
-  global_tags = {
+  global_tags = merge(var.labels, {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared"
-  }
+  })
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1
   }
@@ -105,6 +112,7 @@ module "eks" {
   cluster_log_retention_in_days = 180
   manage_aws_auth = false
   write_kubeconfig = false
+  tags                          = var.labels
 }
 
 data "aws_eks_cluster" "main" {
@@ -117,6 +125,7 @@ data "aws_eks_cluster_auth" "main" {
 
 resource "aws_iam_role" "iam_role_fargate" {
   name = "eks-fargate-profile-${local.cluster_name}"
+  tags = var.labels
   assume_role_policy = jsonencode({
     Statement = [{
       Action = "sts:AssumeRole"
@@ -170,6 +179,7 @@ resource "aws_eks_fargate_profile" "default_namespaces" {
   fargate_profile_name   = "default-namespaces-${local.cluster_name}"
   pod_execution_role_arn = aws_iam_role.iam_role_fargate.arn
   subnet_ids             = module.vpc.aws_subnet_private_prod_ids
+  tags                   = var.labels
   timeouts {
     # For reasons unknown, Fargate profiles can take upward of 20 minutes to
     # delete! I've never seen them go past 30m, though, so this seems OK.
@@ -314,6 +324,7 @@ module "aws_load_balancer_controller" {
   k8s_cluster_name          = data.aws_eks_cluster.main.name
   alb_controller_depends_on = [module.vpc, null_resource.coredns_restart_on_fargate,null_resource.namespace_fargate_logging]
 
+  aws_tags                  = var.labels
 }
 
 
@@ -448,9 +459,9 @@ data "aws_route53_zone" "zone" {
 resource "aws_route53_zone" "cluster" {
   name = "${local.cluster_name}.${local.base_domain}"
 
-  tags = {
+  tags = merge(var.labels, {
     Environment = local.cluster_name
-  }
+  })
   depends_on = [data.aws_route53_zone.zone]
 }
 
@@ -476,10 +487,10 @@ resource "aws_acm_certificate" "cert" {
     "*.${local.cluster_name}.${local.base_domain}"
   ]
   validation_method = "DNS"
-  tags = {
+  tags = merge(var.labels, {
     Name        = "${local.cluster_name}.${local.base_domain}"
     environment = local.cluster_name
-  }
+  })
   depends_on = [
     aws_route53_record.cluster-ns,
   ]

--- a/services/terraform/test-provision/2048_fixture.yml
+++ b/services/terraform/test-provision/2048_fixture.yml
@@ -2,7 +2,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: default
   name: deployment-2048
 spec:
   selector:
@@ -24,7 +23,6 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: default
   name: service-2048
 spec:
   ports:
@@ -39,7 +37,6 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: ingress-2048
-  namespace: default
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /


### PR DESCRIPTION
Use [the provided names and tags](https://github.com/cloudfoundry-incubator/cloud-service-broker/blob/master/docs/brokerpak-specification.md#provision) during provisioning and binding. 

This will help us create a findable "solr" k8s cluster when the broker is deployed. Then the Terraform for the Solr brokerpak can refer to it using a data source and use that cluster by default, unless k8s access details are explicitly provided.