### PR TITLE
Ensure all cluster names are short enough

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 packversion: 1
 name: eks-services-pack
-version: 0.13.0
+version: 0.14.0
 metadata:
   author: Bret Mogilefsky
 platforms:

--- a/services/terraform/eks-bind.tf
+++ b/services/terraform/eks-bind.tf
@@ -10,7 +10,7 @@ output "namespace" { value = kubernetes_namespace.binding.id}
 
 locals {
   name        = var.name != "" ? var.name : "ns-${random_id.name.hex}"
-  cluster_name = trim(var.instance_id,"- ")
+  cluster_name = substr(sha256(var.instance_id), 0, 16)
 }
 
 resource "random_id" "name" {

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -19,7 +19,7 @@ variable labels {
 }
 
 locals {
-  cluster_name    = var.instance_name != "" ? trim(var.instance_name, "- ") : "k8s-${random_id.cluster.hex}"
+  cluster_name    = var.instance_name != "" ? substr(sha256(var.instance_name), 0, 16) : "k8s-${random_id.cluster.hex}"
   cluster_version = "1.18"
   region          = "us-east-1"
   base_domain     = "ssb.datagov.us"


### PR DESCRIPTION
There's a 32 character limit for prefixes on the AWS side, and CF sometimes supplies UUIDs for instanceids.