### PR TITLE
Install zookeeper-operator and solr-operator Helm charts

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 packversion: 1
 name: eks-services-pack
-version: 0.14.0
+version: 0.15.0
 metadata:
   author: Bret Mogilefsky
 platforms:

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -327,6 +327,38 @@ module "aws_load_balancer_controller" {
 }
 
 
+# --------------------------------------------------------------------------
+# Install Solr and Zookeeper operators so that the CRDs will be available 
+# --------------------------------------------------------------------------
+resource "helm_release" "zookeeper-operator" {
+  name            = "zookeeper"
+  chart           = "zookeeper-operator"
+  repository      = "https://charts.pravega.io/"
+  namespace       = "kube-system"
+  cleanup_on_fail = "true"
+  atomic          = "true"
+  depends_on = [
+    module.vpc, 
+    null_resource.coredns_restart_on_fargate, 
+  ]
+}
+
+resource "helm_release" "solr-operator" {
+  name            = "solr"
+  chart           = "solr-operator"
+  repository      = "https://apache.github.io/lucene-solr-operator/charts"
+  namespace       = "kube-system"
+  cleanup_on_fail = "true"
+  atomic          = "true"
+
+  # We need to wait until the zookeeper-operator is live
+  # This should sidestep the issue described here:
+  # https://github.com/bloomberg/solr-operator/issues/122
+    depends_on = [
+    helm_release.zookeeper-operator
+  ]
+}
+
 # ---------------------------------------------------------
 # Provision the Ingress Controller using Helm
 # ---------------------------------------------------------


### PR DESCRIPTION
When we create a binding, we set up a dedicated admin ServiceAccount for that namespace. We don't give out cluster-admin permissions. However, the operators need to create CRDs, which can only be done at the cluster-admin level. So now we install the operators as part of the base k8s deployment.

This also simplifies use of the Solr brokerpak... One can just create `solr-cloud` services without worrying about whether someone has already created a `solr-operator` in the underlying k8s.