### PR TITLE
Make safe names and tokens

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 packversion: 1
 name: eks-services-pack
-version: 0.16.0
+version: 0.17.0
 metadata:
   author: Bret Mogilefsky
 platforms:

--- a/services/terraform/eks-bind.tf
+++ b/services/terraform/eks-bind.tf
@@ -5,7 +5,7 @@ variable "name" { type = string }
 output "kubeconfig" { value = data.template_file.kubeconfig.rendered }
 output "server" { value = data.aws_eks_cluster.main.endpoint }
 output "certificate_authority_data" { value = data.aws_eks_cluster.main.certificate_authority[0].data }
-output "token" { value = data.kubernetes_secret.secret.data.token}
+output "token" { value = base64encode(data.kubernetes_secret.secret.data.token) }
 output "namespace" { value = kubernetes_namespace.binding.id}
 
 locals {

--- a/services/terraform/eks-bind.tf
+++ b/services/terraform/eks-bind.tf
@@ -9,8 +9,8 @@ output "token" { value = data.kubernetes_secret.secret.data.token}
 output "namespace" { value = kubernetes_namespace.binding.id}
 
 locals {
-  name        = var.name != "" ? var.name : "ns-${random_id.name.hex}"
-  cluster_name = substr(sha256(var.instance_id), 0, 16)
+  name        = var.name != "" ? "ns-${var.name}" : "ns-${random_id.name.hex}"
+  cluster_name = "k8s-${substr(sha256(var.instance_id), 0, 16)}"
 }
 
 resource "random_id" "name" {

--- a/services/terraform/eks-provision.tf
+++ b/services/terraform/eks-provision.tf
@@ -19,7 +19,7 @@ variable labels {
 }
 
 locals {
-  cluster_name    = var.instance_name != "" ? substr(sha256(var.instance_name), 0, 16) : "k8s-${random_id.cluster.hex}"
+  cluster_name    = var.instance_name != "" ? "k8s-${substr(sha256(var.instance_name), 0, 16)}" : "k8s-${random_id.cluster.hex}"
   cluster_version = "1.18"
   region          = "us-east-1"
   base_domain     = "ssb.datagov.us"


### PR DESCRIPTION
* Auto-generated input IDs sometimes start with numbers or are longer than are allowed. Hashing and limiting their length ensures we don't randomly see failures when this happens.
* Tokens, when they exist outside a kubeconfig file, are expected to be base64-encoded. That's also coincidentally how our datagov-brokerpak expects them to be passed in. ;)