### PR TITLE
Add external DNS for each Ingress

### DIFF
--- a/.env.secrets-template
+++ b/.env.secrets-template
@@ -1,6 +1,6 @@
 # Provide AWS credentials to be used for provisioning EKS instances here.
 # TODO: Document the process for creating and the permissions needed
-AWS_ACCESS_KEY_ID=""
-AWS_SECRET_ACCESS_KEY=""
-AWS_DEFAULT_REGION="us-west-2"
-AWS_ZONE="set-your.route53.zone"
+AWS_ACCESS_KEY_ID=your_key_id
+AWS_SECRET_ACCESS_KEY=your_access_key
+AWS_DEFAULT_REGION=us-west-2
+AWS_ZONE=set-your.route53.zone

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+# When a tag is pushed, create a tag-named release with the brokerpak in it 
+name: 'release'
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  release:
+    name: 'Release'
+    runs-on: ubuntu-latest
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:  
+    - name: Check out repository
+      uses: actions/checkout@v2
+      with: 
+        fetch-depth: '0'
+
+    - name: Build the brokerpak
+      run: make build
+
+    - name: Rename the brokerpak file based on the tag
+      run: mv eks-services-pak-current.brokerpak eks-services-pak-${GITHUB_REF#refs/*/}.brokerpak
+
+    - name: Create a release and upload the files
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "*.brokerpak"
+        artifactErrorsFailBuild: true
+        token: ${{ secrets.GITHUB_TOKEN }}      

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,7 @@
-# On pull request events, this workflow will run `make build-and-test`. 
-# On push events to the main branch, this workflow will upload a date-named release 
-
-name: 'Test and (Maybe) Release'
+# On pull request events, this workflow will run `make test`. 
+name: 'Test'
 
 on:
-  push:
-    branches:
-    - 'main'
   pull_request:
 
 jobs:
@@ -41,27 +36,8 @@ jobs:
       run: make build
 
     - name: Run examples (tests)
-      # Since they're expensive, only run tests on branches; main is redundant
-      if: github.ref != 'refs/heads/main'
       run: make up && make test && make down
 
-    - name: Bump version and push tag
-      id: bump
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: anothrNick/github-tag-action@1.26.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        WITH_V: true
-        RELEASE_BRANCHES: main
-        INITIAL_VERSION: 0.0.0
-
-    - name: Release pushes to main
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          *.brokerpak
-        tag_name: ${{ steps.bump.outputs.new_tag }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+    - name: Clean up if there was a failure
+      if: ${{ failure() }}
+      run: make demo-down down

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,12 @@ jobs:
 
     # Checkout the repository to the GitHub Actions runner
     steps:
+    - name: Install the eden OSBAPI CLI tool
+      run: |
+        wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | sudo apt-key add -
+        echo "deb http://apt.starkandwayne.com stable main" | sudo tee /etc/apt/sources.list.d/starkandwayne.list
+        sudo apt-get update
+        sudo apt-get install eden
     - uses: actions/checkout@v2
       with: 
         fetch-depth: '0'

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,16 @@ CSB=ghcr.io/gsa/cloud-service-broker:latest-gsa
 SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), user)
 SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), pass)
 
+EDEN_EXEC=eden --client user --client-secret pass --url http://127.0.0.1:8080
+SERVICE_NAME=aws-eks-service
+PLAN_NAME=raw
+CLOUD_PROVISION_PARAMS=$(shell cat examples.json |jq '.[] | select(.service_name | contains("${SERVICENAME}")) | .provision_params')
+CLOUD_BIND_PARAMS=$(shell cat examples.json |jq '.[] | select(.service_name | contains("${SERVICENAME}")) | .bind_params')
 
-clean: down ## Bring down the broker service if it's up and clean out the database
+PREREQUISITES = docker jq kubectl eden
+K := $(foreach prereq,$(PREREQUISITES),$(if $(shell which $(prereq)),some string,$(error "Missing prerequisite commands $(prereq)")))
+
+clean: demo-down down ## Bring down the broker service if it's up and clean out the database
 	@-docker rm -f csb-service
 	@-rm *.brokerpak
 
@@ -37,15 +45,33 @@ up: ## Run the broker service with the brokerpak configured. The broker listens 
 	@echo "csb-service is ready!" ; echo ""
 	@docker ps -l
 
-test: .env.secrets  ## Execute the brokerpak examples against the running broker
-	@echo "Running examples..."
-	docker exec -i csb-service cloud-service-broker client run-examples
-
 down: .env.secrets ## Bring the cloud-service-broker service down
 	@-docker stop csb-service
 
+# Normally we would run 
+# $(CSB) client run-examples --filename examples.json
+# ...to test the brokerpak. However, some of our examples need to run nested.
+# So, we'll run them manually with eden via "demo-up" and "demo-down" targets.
+test: examples.json demo-up demo-run demo-down ## Execute the brokerpak examples against the running broker
+
+demo-up: examples.json ## Provision an EKS instance and output the bound credentials
+	@$(EDEN_EXEC) provision -i instance -s ${SERVICE_NAME}  -p ${PLAN_NAME} -P '$(CLOUD_PROVISION_PARAMS)'
+	@$(EDEN_EXEC) bind -b binding -i instance
+
+demo-run: ## Run tests on the demo instance
+	./test.sh
+
+demo-down: examples.json ## Clean up data left over from tests and demos
+	@echo "Unbinding and deprovisioning the ${SERVICE_NAME} instance"
+	-@$(EDEN_EXEC) unbind -b binding -i instance 2>/dev/null
+	-@$(EDEN_EXEC) deprovision -i instance 2>/dev/null
+
+	@echo "Removing any orphan services from eden"
+	-@rm ~/.eden/config  2>/dev/null ; true
+
+
 all: clean build up test down ## Clean and rebuild, then bring up the server, run the examples, and bring the system down
-.PHONY: all clean build up test down
+.PHONY: all clean build up down test demo-up demo-down test-env-up test-env-down
 
 .env.secrets:
 	$(error Copy .env.secrets-template to .env.secrets, then edit in your own values)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ building, serving, and testing the brokerpak.
    this step should not be necessary in future.)
 
 1. `make` is used for executing docker commands in a meaningful build cycle. 
+1. [`eden`](https://github.com/starkandwayne/eden) is used as a client for testing the brokerpak
 1. Your AWS account credentials (as environment variables) are used for actual
    service provisioning. Set at least:
   * AWS_ACCESS_KEY_ID

--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -48,6 +48,7 @@ provision:
     crds: terraform/provision/crds.tf
     data: terraform/provision/data.tf
     eks: terraform/provision/eks.tf
+    external-dns: terraform/provision/external-dns.tf
     ingress: terraform/provision/ingress.tf
     logging: terraform/provision/logging.tf
     main: terraform/provision/main.tf

--- a/examples.json
+++ b/examples.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Demonstrate provisioning and binding the raw plan",
+    "description": "Provision an EKS cluster, then bind to get a kubeconfig providing access to a namespace.",
+    "service_name": "aws-eks-service",
+    "service_id": "497326e5-a514-4eec-a3e3-5c755da9a866",
+    "plan_id": "f921da02-d9b3-403d-b41f-223f2e61a861",
+    "provision_params": {},
+    "bind_params": {}
+  }
+]

--- a/manifest.yml
+++ b/manifest.yml
@@ -22,23 +22,23 @@ terraform_binaries:
   version: 1.13.3
   source: https://releases.hashicorp.com/terraform-provider-kubernetes/1.13.3/terraform-provider-kubernetes_1.13.3_linux_amd64.zip
 - name: terraform-provider-local
-  version: 1.4.0
-  source: https://releases.hashicorp.com/terraform-provider-local/1.4.0/terraform-provider-local_1.4.0_linux_amd64.zip
+  version: 2.1.0
+  source: https://releases.hashicorp.com/terraform-provider-local/2.1.0/terraform-provider-local_2.1.0_linux_amd64.zip
 - name: terraform-provider-null
-  version: 2.1.0
-  source: https://releases.hashicorp.com/terraform-provider-null/2.1.0/terraform-provider-null_2.1.0_linux_amd64.zip
+  version: 3.1.0
+  source: https://releases.hashicorp.com/terraform-provider-null/3.1.0/terraform-provider-null_3.1.0_linux_amd64.zip
 - name: terraform-provider-random
-  version: 2.1.0
-  source: https://releases.hashicorp.com/terraform-provider-random/2.1.0/terraform-provider-random_2.1.0_linux_amd64.zip
+  version: 3.1.0
+  source: https://releases.hashicorp.com/terraform-provider-random/3.1.0/terraform-provider-random_3.1.0_linux_amd64.zip
 - name: terraform-provider-template
-  version: 2.1.0
-  source: https://releases.hashicorp.com/terraform-provider-template/2.1.0/terraform-provider-template_2.1.0_linux_amd64.zip
+  version: 2.2.0
+  source: https://releases.hashicorp.com/terraform-provider-template/2.2.0/terraform-provider-template_2.2.0_linux_amd64.zip
 - name: terraform-provider-time
-  version: 0.6.0
-  source: https://releases.hashicorp.com/terraform-provider-time/0.6.0/terraform-provider-time_0.6.0_linux_amd64.zip
+  version: 0.7.0
+  source: https://releases.hashicorp.com/terraform-provider-time/0.7.0/terraform-provider-time_0.7.0_linux_amd64.zip
 - name: terraform-provider-tls
-  version: 3.0.0
-  source: https://releases.hashicorp.com/terraform-provider-tls/3.0.0/terraform-provider-tls_3.0.0_linux_amd64.zip
+  version: 3.1.0
+  source: https://releases.hashicorp.com/terraform-provider-tls/3.1.0/terraform-provider-tls_3.1.0_linux_amd64.zip
 
 service_definitions:
 - eks-service-definition.yml

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 packversion: 1
-name: eks-services-pack
-version: 0.25.0
+name: eks-services-pak
+version: current
 metadata:
   author: Bret Mogilefsky
 platforms:

--- a/terraform/provision/2048_fixture.yml
+++ b/terraform/provision/2048_fixture.yml
@@ -33,7 +33,7 @@ spec:
   selector:
     app.kubernetes.io/name: app-2048
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-2048
@@ -45,6 +45,9 @@ spec:
   - http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: service-2048
-          servicePort: 80              
+          service:
+            name: service-2048
+            port: 
+              number: 80              

--- a/terraform/provision/crds.tf
+++ b/terraform/provision/crds.tf
@@ -5,6 +5,7 @@ resource "helm_release" "zookeeper-operator" {
   name            = "zookeeper"
   chart           = "zookeeper-operator"
   repository      = "https://charts.pravega.io/"
+  version         = "0.2.9"
   namespace       = "kube-system"
   cleanup_on_fail = "true"
   atomic          = "true"

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -1,6 +1,6 @@
 locals {
   cluster_name    = var.instance_name != "" ? "k8s-${substr(sha256(var.instance_name), 0, 16)}" : "k8s-${random_id.cluster.hex}"
-  cluster_version = "1.18"
+  cluster_version = "1.19"
 }
 
 module "eks" {

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -83,7 +83,7 @@ resource "aws_eks_fargate_profile" "default_namespaces" {
     EOF
   }
 
-  depends_on             = [module.eks.cluster_id]
+  depends_on = [module.eks.cluster_id]
 }
 
 # Resources referring to cluster attributes should make use of these 

--- a/terraform/provision/external-dns.tf
+++ b/terraform/provision/external-dns.tf
@@ -1,0 +1,150 @@
+# Modeled after an example here:
+# https://tech.polyconseil.fr/external-dns-helm-terraform.html
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  oidc_url = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+}
+
+resource "aws_iam_role" "external_dns" {
+  name               = "${local.cluster_name}-external-dns"
+  tags               = var.labels
+  assume_role_policy = <<-EOF
+    {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Action": "sts:AssumeRoleWithWebIdentity",
+        "Effect": "Allow",
+        "Principal": {
+            "Federated": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_url}"
+        },
+        "Condition": {
+            "StringEquals": {
+            "${local.oidc_url}:sub": "system:serviceaccount:kube-system:external-dns"
+            }
+        }
+        }
+    ]
+    }
+    EOF
+}
+
+resource "aws_iam_role_policy" "external_dns" {
+  name_prefix = "${local.cluster_name}-external-dns"
+  role        = aws_iam_role.external_dns.name
+  policy      = <<-EOF
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "route53:ChangeResourceRecordSets"
+                ],
+                "Resource": [
+                    "arn:aws:route53:::hostedzone/${aws_route53_zone.cluster.zone_id}"
+                ]
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "route53:ListHostedZones",
+                    "route53:ListResourceRecordSets"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
+        ]
+    }  
+    EOF
+}
+
+resource "kubernetes_service_account" "external_dns" {
+  metadata {
+    name      = "external-dns"
+    namespace = "kube-system"
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.external_dns.arn
+    }
+  }
+  automount_service_account_token = true
+}
+
+resource "kubernetes_cluster_role" "external_dns" {
+  metadata {
+    name = "external-dns"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["services", "pods", "nodes", "endpoints"]
+    verbs      = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["extensions", "networking.k8s.io"]
+    resources  = ["ingresses"]
+    verbs      = ["get", "list", "watch"]
+  }
+  rule {
+    api_groups = ["networking.istio.io"]
+    resources  = ["gateways"]
+    verbs      = ["get", "list", "watch"]
+  }
+  depends_on = [
+    aws_eks_fargate_profile.default_namespaces
+  ]
+}
+
+resource "kubernetes_cluster_role_binding" "external_dns" {
+  metadata {
+    name = "external-dns"
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role.external_dns.metadata.0.name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.external_dns.metadata.0.name
+    namespace = kubernetes_service_account.external_dns.metadata.0.namespace
+  }
+  depends_on = [
+    aws_eks_fargate_profile.default_namespaces
+  ]
+}
+
+# Chart docs: https://github.com/bitnami/charts/tree/master/bitnami/external-dns/
+resource "helm_release" "external_dns" {
+  name       = "external-dns"
+  namespace  = kubernetes_service_account.external_dns.metadata.0.namespace
+  wait       = true
+  atomic     = true
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "external-dns"
+  version    = "4.9.3"
+  dynamic "set" {
+    for_each = {
+      "rbac.create"           = false
+      "serviceAccount.create" = false
+      "serviceAccount.name"   = kubernetes_service_account.external_dns.metadata.0.name
+      "rbac.pspEnabled"       = false
+      "name"                  = "${local.cluster_name}-external-dns"
+      "provider"              = "aws"
+      "policy"                = "sync"
+      "logLevel"              = "info"
+      "sources"               = "{ingress}"
+      "aws.zoneType"          = ""
+      "txtPrefix"             = "edns-"
+      "aws.region"            = data.aws_region.current.name
+      "fqdnTemplates"         = "\\{\\{.Name\\}\\}.${local.domain_name}"
+    }
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+}

--- a/terraform/provision/external-dns.tf
+++ b/terraform/provision/external-dns.tf
@@ -71,6 +71,9 @@ resource "kubernetes_service_account" "external_dns" {
     }
   }
   automount_service_account_token = true
+  depends_on = [
+    aws_eks_fargate_profile.default_namespaces
+  ]
 }
 
 resource "kubernetes_cluster_role" "external_dns" {
@@ -147,4 +150,7 @@ resource "helm_release" "external_dns" {
       value = set.value
     }
   }
+  depends_on = [
+    aws_eks_fargate_profile.default_namespaces
+  ]
 }

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -91,7 +91,9 @@ resource "helm_release" "ingress_nginx" {
   #   }
   #   command = "helm --kubeconfig <(echo $KUBECONFIG | base64 -d) test --logs -n ${self.namespace} ${self.name}"
   # }
-
+  depends_on = [
+    aws_eks_fargate_profile.default_namespaces
+  ]
 }
 
 # Give the controller time to react to any recent events (eg an ingress was
@@ -112,12 +114,12 @@ resource "kubernetes_ingress" "alb_to_nginx" {
     }
 
     annotations = {
-      "alb.ingress.kubernetes.io/healthcheck-path" = "/"
-      "alb.ingress.kubernetes.io/scheme"           = "internet-facing"
-      "alb.ingress.kubernetes.io/target-type"      = "ip"
-      "kubernetes.io/ingress.class"                = "alb"
-      "alb.ingress.kubernetes.io/certificate-arn"  = "${aws_acm_certificate.cert.arn}"
-      "alb.ingress.kubernetes.io/listen-ports" = "[{\"HTTP\":80}, {\"HTTPS\":443}]",
+      "alb.ingress.kubernetes.io/healthcheck-path"     = "/"
+      "alb.ingress.kubernetes.io/scheme"               = "internet-facing"
+      "alb.ingress.kubernetes.io/target-type"          = "ip"
+      "kubernetes.io/ingress.class"                    = "alb"
+      "alb.ingress.kubernetes.io/certificate-arn"      = aws_acm_certificate.cert.arn
+      "alb.ingress.kubernetes.io/listen-ports"         = "[{\"HTTP\":80}, {\"HTTPS\":443}]",
       "alb.ingress.kubernetes.io/actions.ssl-redirect" = "{\"Type\": \"redirect\", \"RedirectConfig\": { \"Protocol\": \"HTTPS\", \"Port\": \"443\", \"StatusCode\": \"HTTP_301\"}}",
     }
   }
@@ -147,7 +149,6 @@ resource "kubernetes_ingress" "alb_to_nginx" {
     helm_release.ingress_nginx,
     time_sleep.alb_controller_destroy_delay,
     module.aws_load_balancer_controller,
-    aws_acm_certificate_validation.cert
   ]
 }
 
@@ -158,8 +159,7 @@ resource "kubernetes_ingress" "alb_to_nginx" {
 
 # get externally configured DNS Zone 
 data "aws_route53_zone" "zone" {
-  name       = local.base_domain
-  depends_on = [module.aws_load_balancer_controller, helm_release.ingress_nginx]
+  name = local.base_domain
 }
 
 # Create Hosted Zone for Cluster specific Subdomain name
@@ -170,7 +170,6 @@ resource "aws_route53_zone" "cluster" {
   tags = merge(var.labels, {
     Environment = local.cluster_name
   })
-  depends_on = [data.aws_route53_zone.zone]
 }
 
 # Create the NS record in main domain hosted zone for sub domain hosted zone
@@ -180,11 +179,6 @@ resource "aws_route53_record" "cluster-ns" {
   type    = "NS"
   ttl     = "30"
   records = aws_route53_zone.cluster.name_servers
-
-  depends_on = [
-    aws_route53_zone.cluster,
-    data.aws_route53_zone.zone,
-  ]
 }
 
 # Create ACM certificate for the sub-domain
@@ -199,9 +193,6 @@ resource "aws_acm_certificate" "cert" {
     Name        = local.domain_name
     environment = local.cluster_name
   })
-  depends_on = [
-    aws_route53_record.cluster-ns,
-  ]
 }
 
 # Validate the certificate using DNS method
@@ -211,7 +202,6 @@ resource "aws_route53_record" "cert_validation" {
   zone_id    = aws_route53_zone.cluster.id
   records    = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
   ttl        = 60
-  depends_on = [aws_route53_record.cluster-ns]
 }
 
 resource "aws_acm_certificate_validation" "cert" {
@@ -221,12 +211,6 @@ resource "aws_acm_certificate_validation" "cert" {
 
 # Get the Ingress for the ALB
 data "aws_elb_hosted_zone_id" "elb_zone_id" {}
-
-# Wait 30 seconds before trying to use the ingress-nginx ALB hostname in DNS
-resource "time_sleep" "nginx_alb_creation_delay" {
-  create_duration = "30s"
-  depends_on      = [kubernetes_ingress.alb_to_nginx]
-}
 
 # Create CNAME record in sub-domain hosted zone for the ALB
 resource "aws_route53_record" "www" {
@@ -239,9 +223,4 @@ resource "aws_route53_record" "www" {
     zone_id                = data.aws_elb_hosted_zone_id.elb_zone_id.id
     evaluate_target_health = true
   }
-  depends_on = [
-    aws_acm_certificate.cert,
-    aws_acm_certificate_validation.cert,
-    time_sleep.nginx_alb_creation_delay
-  ]
 }

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -53,12 +53,12 @@ resource "helm_release" "ingress_nginx" {
       "controller.autoscaling.enabled"               = true,
       "controller.publishService.enabled"            = false,
       "controller.extraArgs.publish-status-address"  = local.domain_name,
-      "serviceAccount.create" = true,
-      "rbac.create"           = true,
-      "clusterName"           = module.eks.cluster_id,
-      "region"                = local.region,
-      "vpcId"                 = module.vpc.aws_vpc_id,
-      "aws_iam_role_arn"      = module.aws_load_balancer_controller.aws_iam_role_arn
+      "serviceAccount.create"                        = true,
+      "rbac.create"                                  = true,
+      "clusterName"                                  = module.eks.cluster_id,
+      "region"                                       = local.region,
+      "vpcId"                                        = module.vpc.aws_vpc_id,
+      "aws_iam_role_arn"                             = module.aws_load_balancer_controller.aws_iam_role_arn
     }
     content {
       name  = set.key
@@ -128,7 +128,7 @@ resource "kubernetes_ingress" "alb_to_nginx" {
     rule {
       http {
         path {
-          path = "/*"          
+          path = "/*"
           backend {
             service_name = "ssl-redirect"
             service_port = "use-annotation"
@@ -197,11 +197,11 @@ resource "aws_acm_certificate" "cert" {
 
 # Validate the certificate using DNS method
 resource "aws_route53_record" "cert_validation" {
-  name       = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
-  type       = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
-  zone_id    = aws_route53_zone.cluster.id
-  records    = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
-  ttl        = 60
+  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
+  zone_id = aws_route53_zone.cluster.id
+  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
+  ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "cert" {

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -121,6 +121,7 @@ resource "kubernetes_ingress" "alb_to_nginx" {
       "alb.ingress.kubernetes.io/certificate-arn"      = aws_acm_certificate.cert.arn
       "alb.ingress.kubernetes.io/listen-ports"         = "[{\"HTTP\":80}, {\"HTTPS\":443}]",
       "alb.ingress.kubernetes.io/actions.ssl-redirect" = "{\"Type\": \"redirect\", \"RedirectConfig\": { \"Protocol\": \"HTTPS\", \"Port\": \"443\", \"StatusCode\": \"HTTP_301\"}}",
+      "alb.ingress.kubernetes.io/load-balancer-attributes" = "routing.http2.enabled=true,idle_timeout.timeout_seconds=60",
     }
   }
 

--- a/terraform/provision/rbac.tf
+++ b/terraform/provision/rbac.tf
@@ -12,7 +12,7 @@ resource "kubernetes_role" "namespace_admin" {
     resources  = ["*"]
     verbs      = ["*"]
   }
-  
+
   depends_on = [
     aws_eks_fargate_profile.default_namespaces
   ]

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -1,18 +1,18 @@
 
-variable instance_name {
+variable "instance_name" {
   type    = string
   default = ""
 }
 
-variable labels {
-  type    = map
+variable "labels" {
+  type    = map(any)
   default = {}
 }
 
-variable zone {
+variable "zone" {
   type = string
 }
 
-variable region {
+variable "region" {
   type = string
 }

--- a/terraform/provision/vpc.tf
+++ b/terraform/provision/vpc.tf
@@ -1,5 +1,5 @@
 locals {
-  region          = var.region
+  region = var.region
 }
 
 module "vpc" {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+export SERVICE_INFO=$(echo "eden --client user --client-secret pass --url http://127.0.0.1:8080 credentials -b binding -i instance")
+
+# Set up the kubeconfig
+export KUBECONFIG=$(mktemp)
+${SERVICE_INFO} | jq -r '.kubeconfig' > ${KUBECONFIG}
+
+# Grab the domain name
+export DOMAIN_NAME=$(${SERVICE_INFO} | jq -r '.domain_name')
+
+echo "Deploying the test fixture..."
+kubectl apply -f terraform/provision/2048_fixture.yml
+
+echo "Waiting 3 minutes for the workload to start and the DNS entry to be created..."
+sleep 180
+
+echo "Testing that the ingress is resolvable via SSL, and that it's properly pointing at the 2048 app..."
+curl --silent --show-error https://ingress-2048.${DOMAIN_NAME} | fgrep '<title>2048</title>' > /dev/null
+
+echo "Success! You can try the fixture yourself by visiting:"
+echo "https://ingress-2048.${DOMAIN_NAME}"
+
+rm ${KUBECONFIG}

--- a/test.sh
+++ b/test.sh
@@ -7,9 +7,12 @@ export SERVICE_INFO=$(echo "eden --client user --client-secret pass --url http:/
 # Set up the kubeconfig
 export KUBECONFIG=$(mktemp)
 ${SERVICE_INFO} | jq -r '.kubeconfig' > ${KUBECONFIG}
-
-# Grab the domain name
 export DOMAIN_NAME=$(${SERVICE_INFO} | jq -r '.domain_name')
+
+echo "To work directly with the instance:"
+echo "export KUBECONFIG=${KUBECONFIG}"
+echo "export DOMAIN_NAME=${DOMAIN_NAME}"
+echo "Running tests..."
 
 echo "Deploying the test fixture..."
 kubectl apply -f terraform/provision/2048_fixture.yml
@@ -17,10 +20,46 @@ kubectl apply -f terraform/provision/2048_fixture.yml
 echo "Waiting 3 minutes for the workload to start and the DNS entry to be created..."
 sleep 180
 
+export TEST_HOST=ingress-2048.${DOMAIN_NAME}
+export TEST_URL=https://${TEST_HOST}
+
 echo "Testing that the ingress is resolvable via SSL, and that it's properly pointing at the 2048 app..."
-curl --silent --show-error https://ingress-2048.${DOMAIN_NAME} | fgrep '<title>2048</title>' > /dev/null
+curl --silent --show-error ${TEST_URL} | fgrep '<title>2048</title>' > /dev/null
 
 echo "Success! You can try the fixture yourself by visiting:"
-echo "https://ingress-2048.${DOMAIN_NAME}"
+echo ${TEST_URL}
+
+echo "Testing that connections are closed after 60s of inactivity..."
+
+
+# timeout(): Test whether a command finishes before a deadline 
+# Usage:
+#   timeout <cmd...> 
+# Optionally, set TIMEOUT_DEADLINE_SECS to something other than the default 65s.
+# You may want to wrap more complex commands in a function and pass that.
+#
+# This idea for testing whether a command times out comes from:
+# http://blog.mediatribe.net/fr/node/72/index.html
+function timeout () {
+    local timeout=${TIMEOUT_DEADLINE_SECS:-65}
+    "$@" & 
+    sleep ${timeout}
+    # If the process has already exited, kill returns a non-zero exit status If
+    # the process hasn't already exited, kill returns a zero exit status
+    if kill $! # 2> /dev/null 
+    then
+        # The command was still running at the deadline and had to be killed
+        echo "The command did NOT exit within ${timeout} seconds."
+        return 1
+    else
+        # ...the command had already exited by the deadline without being killed
+        echo "The command exited within ${timeout} seconds."
+    fi
+}
+
+# Hold an SSL connection open until the connection is closed from the other end,
+# or the process is killed. timeout() will complain if it takes longer than 65
+# seconds to end on its own.
+timeout openssl s_client -quiet -connect ${TEST_HOST}:443 2> /dev/null
 
 rm ${KUBECONFIG}


### PR DESCRIPTION
Addresses https://github.com/GSA/eks-brokerpak/issues/7

- Upgrade EKS to 1.19 and make the fixture use the final networking API v1
- Add a role with a policy sufficient to edit entries in Route53
- Add a service account that can assume that role
- Give the service account access to watch all the APIs it needs
- Add the external-dns helm chart, and configure it to use that service account
- Set ingress_nginx to configure all ingresses to point to the ALB that points to it