### PR TITLE
Strict TLS 1.2 support for ALBs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       # Docs for this method:
       # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
       run: |
-        INSTANCE_NAME="$(echo ci-${GITHUB_REF#refs/*/}-${GITHUB_RUN_ID})"
+        INSTANCE_NAME="$(echo ci-${{ github.event.pull_request.number }}-${GITHUB_RUN_ID})"
         echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
 
     - name: Run examples (tests)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,8 @@ jobs:
       # Docs for this method:
       # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
       run: |
-        echo "INSTANCE_NAME=${GITHUB_HEAD_REF:0:20}-${GITHUB_RUN_ID}" >> $GITHUB_ENV
-        grep INSTANCE_NAME $GITHUB_ENV
+        INSTANCE_NAME="$(echo ${GITHUB_HEAD_REF:0:20}-${GITHUB_RUN_ID} | tr [:upper:] [:lower:] | sed -e 's/[^a-z0-9-]\+/-/g')"  # lowercase, slugify
+        echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
 
     - name: Run examples (tests)
       run: make up && make test && make down

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       # Docs for this method:
       # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
       run: |
-        INSTANCE_NAME="$(echo ${GITHUB_HEAD_REF:0:20}-${GITHUB_RUN_ID} | tr [:upper:] [:lower:] | sed -e 's/[^a-z0-9-]\+/-/g')"  # lowercase, slugify
+        INSTANCE_NAME="$(echo ci-${GITHUB_REF#refs/*/}-${GITHUB_RUN_ID})"
         echo "INSTANCE_NAME=${INSTANCE_NAME}" | tee -a $GITHUB_ENV
 
     - name: Run examples (tests)

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ brokerpak concept, and to the Pivotal team running with the concept!
 Each brokered AWS EKS provides:
 
 - unique, isolated VPC with multiple AZs
-- a single unique namespace
-- Kubernetes notes provided by AWS EKS Fargate
-- RBAC
+- Kubernetes nodes provided by AWS EKS Fargate
+- Bound credential permissions are limited by namespace
 - cluster-wide logging to AWS CloudWatch with fluent-bit
-- AWS [ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/) for cluster-wide ingress, WAFv2 integration
-- nginx Ingress controller
-- AWS Route53 integration with [ExternalDNS](https://github.com/kubernetes-sigs/external-dns)
-- [ZooKeeper Operator](https://github.com/pravega/zookeeper-operator) for
+- Automatic TLS configuration using AWS Certificate Manager (ACM) 
+- Cluster-wide ingress load-balancing with AWS-specific features (eg WAFv2 integration) [via ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/)
+- nginx ingress controller for routing and IaaS-independent deployments
+- Automatic DNS configuration using AWS Route53 [via ExternalDNS](https://github.com/kubernetes-sigs/external-dns)
+- [ZooKeeper CRDs](https://github.com/pravega/zookeeper-operator) ready for
   managing Apache ZooKeeper clusters
-- [Solr Operator](https://github.com/apache/solr-operator) for managing
+- [Solr CRDs](https://github.com/apache/solr-operator) for managing
   SolrCloud instances
 
 
@@ -137,4 +137,3 @@ This project is in the worldwide [public domain](LICENSE.md). As stated in [CONT
 > This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 >
 > All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
-

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ docs.
 Huge props go to @josephlewis42 of Google for publishing and publicizing the
 brokerpak concept, and to the Pivotal team running with the concept!
 
+
+## Features/components
+
+Each brokered AWS EKS provides:
+
+- unique, isolated VPC with multiple AZs
+- a single unique namespace
+- Kubernetes notes provided by AWS EKS Fargate
+- RBAC
+- cluster-wide logging to AWS CloudWatch with fluent-bit
+- AWS [ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/) for cluster-wide ingress, WAFv2 integration
+- nginx Ingress controller
+- AWS Route53 integration with [ExternalDNS](https://github.com/kubernetes-sigs/external-dns)
+- [ZooKeeper Operator](https://github.com/pravega/zookeeper-operator) for
+  managing Apache ZooKeeper clusters
+- [Solr Operator](https://github.com/apache/solr-operator) for managing
+  SolrCloud instances
+
+
 ## Development Prerequisites
 
 1. [Docker Desktop (for Mac or

--- a/terraform/provision/crds.tf
+++ b/terraform/provision/crds.tf
@@ -19,6 +19,7 @@ resource "helm_release" "solr-operator" {
   name            = "solr"
   chart           = "solr-operator"
   repository      = "https://solr.apache.org/charts"
+  version         = "0.2.8"
   namespace       = "kube-system"
   cleanup_on_fail = "true"
   atomic          = "true"

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -174,6 +174,7 @@ resource "kubernetes_ingress" "alb_to_nginx" {
       "alb.ingress.kubernetes.io/load-balancer-attributes"   = "routing.http2.enabled=true,idle_timeout.timeout_seconds=60",
       "alb.ingress.kubernetes.io/scheme"                     = "internet-facing"
       "alb.ingress.kubernetes.io/shield-advanced-protection" = "false"
+      "alb.ingress.kubernetes.io/ssl-policy"                 = "ELBSecurityPolicy-TLS-1-2-2017-01"
       "alb.ingress.kubernetes.io/target-type"                = "ip"
       "alb.ingress.kubernetes.io/wafv2-acl-arn"              = aws_wafv2_web_acl.waf_acl.arn
       "kubernetes.io/ingress.class"                          = "alb"

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -167,16 +167,16 @@ resource "kubernetes_ingress" "alb_to_nginx" {
     }
 
     annotations = {
-      "alb.ingress.kubernetes.io/healthcheck-path"           = "/"
-      "alb.ingress.kubernetes.io/scheme"                     = "internet-facing"
-      "alb.ingress.kubernetes.io/target-type"                = "ip"
-      "kubernetes.io/ingress.class"                          = "alb"
-      "alb.ingress.kubernetes.io/certificate-arn"            = aws_acm_certificate.cert.arn
-      "alb.ingress.kubernetes.io/listen-ports"               = "[{\"HTTP\":80}, {\"HTTPS\":443}]",
       "alb.ingress.kubernetes.io/actions.ssl-redirect"       = "{\"Type\": \"redirect\", \"RedirectConfig\": { \"Protocol\": \"HTTPS\", \"Port\": \"443\", \"StatusCode\": \"HTTP_301\"}}",
+      "alb.ingress.kubernetes.io/certificate-arn"            = aws_acm_certificate.cert.arn
+      "alb.ingress.kubernetes.io/healthcheck-path"           = "/"
+      "alb.ingress.kubernetes.io/listen-ports"               = "[{\"HTTP\":80}, {\"HTTPS\":443}]",
       "alb.ingress.kubernetes.io/load-balancer-attributes"   = "routing.http2.enabled=true,idle_timeout.timeout_seconds=60",
-      "alb.ingress.kubernetes.io/wafv2-acl-arn"              = aws_wafv2_web_acl.waf_acl.arn
+      "alb.ingress.kubernetes.io/scheme"                     = "internet-facing"
       "alb.ingress.kubernetes.io/shield-advanced-protection" = "false"
+      "alb.ingress.kubernetes.io/target-type"                = "ip"
+      "alb.ingress.kubernetes.io/wafv2-acl-arn"              = aws_wafv2_web_acl.waf_acl.arn
+      "kubernetes.io/ingress.class"                          = "alb"
     }
   }
 


### PR DESCRIPTION
- Sort annotations to 🤞  reduce merge conflicts
- Use a TLS 1.2-only ALB policy.

https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html
