### PR TITLE
Non destructive renaming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PLAN_NAME=raw
 # invocations, and make it obvious which resources correspond to which CI run.
 INSTANCE_NAME ?= instance-$(USER)
 
-CLOUD_PROVISION_PARAMS="{ \"cluster_name\": \"${INSTANCE_NAME}\" }"
+CLOUD_PROVISION_PARAMS="{ \"subdomain\": \"${INSTANCE_NAME}\" }"
 CLOUD_BIND_PARAMS="{}"
 
 PREREQUISITES = docker jq kubectl eden
@@ -43,6 +43,7 @@ up: ## Run the broker service with the brokerpak configured. The broker listens 
 	-p 8080:8080 \
 	-e SECURITY_USER_NAME=$(SECURITY_USER_NAME) \
 	-e SECURITY_USER_PASSWORD=$(SECURITY_USER_PASSWORD) \
+	-e GSB_DEBUG=true \
 	-e "DB_TYPE=sqlite3" \
 	-e "DB_PATH=/tmp/csb-db" \
 	--env-file .env.secrets \

--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -20,20 +20,20 @@ plans:
 provision:
   plan_inputs: []
   user_inputs: 
-  - field_name: cluster_name
+  - field_name: subdomain
     required: false
     type: string    
     constraints:
-      # The EKS module limits the cluster prefix to 32 characters. The ALB Load
-      # Balancer module adds another 32 to generate an IAM ID that must be less
-      # than 64 characters. So we limit the length of the input here to 30 which
-      # keeps the generated ID under that 64-character limit.
-      maxLength: 30
+      maxLength: 64
       minLength: 2
       pattern: ^[a-z0-9][a-z0-9-]*[a-z0-9]$
-    default: ${str.truncate(30, "${request.instance_id}")}
-    details: A name for the cluster, up to 30 alphanumeric characters
+    default: ${str.truncate(64, "${request.instance_id}")}
+    details: A subdomain to use for the cluster instance. Default is the instance ID.
   computed_inputs:
+    - name: instance_name
+    required: true
+    type: string
+    default: ${request.instance_id}
   - name: labels
     default: ${json.marshal(request.default_labels)}
     overwrite: true
@@ -53,10 +53,6 @@ provision:
     required: true
     type: string
     details: The primary domain name to use for external ingress
-  - field_name: cluster_name
-    required: true
-    type: string
-    details: The name of the created cluster
   template_refs: 
     crds: terraform/provision/crds.tf
     data: terraform/provision/data.tf
@@ -74,11 +70,7 @@ bind:
   plan_inputs: []
   user_inputs: []
   computed_inputs:
-  - name: cluster_name
-    required: true
-    type: string
-    default: ${instance.details["cluster_name"]}
-  - name: instance_id
+  - name: instance_name
     default: ${request.instance_id}
     required: true
     overwrite: true

--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -30,7 +30,7 @@ provision:
     default: ${str.truncate(64, "${request.instance_id}")}
     details: A subdomain to use for the cluster instance. Default is the instance ID.
   computed_inputs:
-    - name: instance_name
+  - name: instance_name
     required: true
     type: string
     default: ${request.instance_id}

--- a/terraform/bind/data.tf
+++ b/terraform/bind/data.tf
@@ -1,5 +1,5 @@
 locals {
-  cluster_name = var.cluster_name
+  cluster_name = "k8s-${substr(sha256(var.instance_name), 0, 16)}"
   namespace    = "default"
 }
 

--- a/terraform/bind/variables.tf
+++ b/terraform/bind/variables.tf
@@ -1,3 +1,2 @@
-variable "instance_id" { type = string }
-variable "cluster_name" { type = string }
+variable "instance_name" { type = string }
 

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -16,7 +16,7 @@ module "eks" {
   cluster_log_retention_in_days = 180
   manage_aws_auth               = false
   write_kubeconfig              = false
-  tags                          = var.labels
+  tags                          = merge(var.labels, { "domain" = local.domain })
 }
 
 resource "aws_iam_role" "iam_role_fargate" {

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -1,5 +1,5 @@
 locals {
-  cluster_name    = var.cluster_name != "" ? "${var.cluster_name}" : "k8s-${random_id.cluster.hex}"
+  cluster_name    = "k8s-${substr(sha256(var.instance_name), 0, 16)}"
   cluster_version = "1.19"
 }
 

--- a/terraform/provision/external-dns.tf
+++ b/terraform/provision/external-dns.tf
@@ -143,7 +143,7 @@ resource "helm_release" "external_dns" {
       "aws.zoneType"          = ""
       "txtPrefix"             = "edns-"
       "aws.region"            = data.aws_region.current.name
-      "fqdnTemplates"         = "\\{\\{.Name\\}\\}.${local.domain_name}"
+      "fqdnTemplates"         = "\\{\\{.Name\\}\\}.${local.domain}"
     }
     content {
       name  = set.key

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -1,7 +1,7 @@
 locals {
   base_domain = var.zone
-  domain = "${local.subdomain}.${local.base_domain}"
-  subdomain       = var.subdomain
+  domain      = "${local.subdomain}.${local.base_domain}"
+  subdomain   = var.subdomain
 }
 
 # We need an OIDC provider for the ALB ingress controller to work
@@ -24,7 +24,7 @@ module "aws_load_balancer_controller" {
   aws_region_name           = data.aws_region.current.name
   k8s_cluster_name          = data.aws_eks_cluster.main.name
   alb_controller_depends_on = [module.vpc, aws_eks_fargate_profile.default_namespaces, null_resource.namespace_fargate_logging]
-  aws_tags                  = var.labels
+  aws_tags                  = merge(var.labels, { "domain" = local.domain })
 }
 
 # ---------------------------------------------------------
@@ -227,6 +227,7 @@ resource "aws_route53_zone" "cluster" {
   force_destroy = true
   tags = merge(var.labels, {
     Environment = local.cluster_name
+    domain      = local.domain
   })
 }
 
@@ -248,7 +249,7 @@ resource "aws_acm_certificate" "cert" {
   ]
   validation_method = "DNS"
   tags = merge(var.labels, {
-    Name        = local.domain
+    domain      = local.domain
     environment = local.cluster_name
   })
 }

--- a/terraform/provision/outputs.tf
+++ b/terraform/provision/outputs.tf
@@ -1,2 +1,1 @@
-output "domain_name" { value = local.domain_name }
-output "cluster_name" { value = local.cluster_name }
+output "domain_name" { value = local.domain }

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -1,5 +1,10 @@
 
-variable "cluster_name" {
+variable "subdomain" {
+  type    = string
+  default = ""
+}
+
+variable "instance_name" {
   type    = string
   default = ""
 }

--- a/terraform/provision/vpc.tf
+++ b/terraform/provision/vpc.tf
@@ -16,7 +16,8 @@ module "vpc" {
   # Tag subnets for use by AWS' load-balancers and the ALB ingress controllers
   # See https://aws.amazon.com/premiumsupport/knowledge-center/eks-vpc-subnet-discovery/
   global_tags = merge(var.labels, {
-    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared",
+    "domain" = local.domain
   })
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1


### PR DESCRIPTION
This will destroy existing k8s clusters to replace them with more random names. However, from here out the specified subdomain is *only* used for DNS, which makes it easier to change the name and avoid collisions in future.