### PR TITLE
Use an ingress-nginx controller that still supports v1beta1 (needed by the solr-operator)

### DIFF
--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -34,6 +34,7 @@ resource "helm_release" "ingress_nginx" {
   name       = "ingress-nginx"
   chart      = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
+  version    = "3.32.0"
 
   namespace       = "kube-system"
   cleanup_on_fail = "true"


### PR DESCRIPTION
See https://github.com/apache/solr-operator/issues/277