### PR TITLE
Upgrade Terraform providers and modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ terraform/*/.cache
 terraform/*/.ash_history
 terraform/*/.kube
 terraform/*/.terraform.d
+terraform/*/kubeconfig_*

--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,9 @@ app/*
 backend.tfvars
 .env.secrets
 *.brokerpak
-services/terraform/test-provision/kubeconfig*
+terraform/*/.config
+terraform/*/.cache
+
+terraform/*/.ash_history
+terraform/*/.kube
+terraform/*/.terraform.d

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ make clean
 ```
 The built brokerpak files will be removed.
 
+## Cleaning up a botched service instance
+
+You might end up in a situation where the broker is failing to cleanup resources that it has provisioned or bound. When that happens, follow [this procedure](docs/instance-cleanup.md).
+
 ## Contributing
 
 Check

--- a/docs/instance-cleanup.md
+++ b/docs/instance-cleanup.md
@@ -1,0 +1,40 @@
+# Cleaning up a botched service instance
+
+You might end up in a situation where the broker is failing to cleanup resources that it has provisioned or bound. When that happens, follow this procedure:
+
+1. Log into the AWS Console as a power user 
+    - In the data.gov deployment, that's `SSBDev` or `SSBAdmin`.
+
+1. Make sure you’re looking at the right region in the console (and double-check it if you're in the "global" region in steps below)
+    - In the data.gov deployment, that's `us-west-2`.
+
+1. Kubernetes cluster> EKS > cluster name > Configuration tab > Compute
+
+    - Delete Fargate Profile if it exists (takes a few minutes)
+
+1. Kubernetes cluster> EKS > cluster name
+
+    - Delete the cluster (takes a few minutes but you can go do other things)
+
+1. EC2 > Load Balancers
+
+    - Look for one tagged with the name of the k8s cluster and delete it if present
+1. Certificate Manager
+    - Delete corresponding certificate (it should not be in use if you already deleted the Load Balancer)
+1. Route 53 > Hosted zones
+    - Delete the corresponding domain
+    - Delete the NS record for that domain in the top-level domain (eg ssb-dev.datagov.us)
+1. VPC > NAT Gateways
+    - Look for the one tagged with the k8s cluster name and delete it
+1. VPC > Your VPCs
+    - Look for the one tagged with the k8s cluster name and delete it
+      - If there’s anything red in the confirmation dialog, you missed something
+1. CloudWatch > Logs > Log Groups
+    - Delete (up to) two matching log groups
+1. AWS Firewall Manager > AWS WAF > Web ACLs
+    - Delete the corresponding WAF rule
+1. IAM > Access Management > Roles
+    - Search for the cluster name
+    - Delete all the related roles
+
+

--- a/eks-service-definition.yml
+++ b/eks-service-definition.yml
@@ -48,6 +48,10 @@ provision:
     details: "The AWS region in which to create k8s instances"
     overwrite: true
     default: ${config("aws.default_region")}
+  - name: write_kubeconfig
+    type: boolean
+    overwrite: true
+    default: false
   outputs:
   - field_name: domain_name
     required: true

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,7 @@ terraform_binaries:
   version: 0.12.30
   source: https://github.com/hashicorp/terraform/archive/v0.12.30.zip  
 - name: terraform-provider-aws
-  version: 2.67.0
+  version: 3.61.0
   source: https://releases.hashicorp.com/terraform-provider-aws/2.67.0/terraform-provider-aws_2.67.0_linux_amd64.zip
 - name: terraform-provider-helm
   version: 1.2.0

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,17 +8,17 @@ platforms:
   arch: amd64
 terraform_binaries:
 - name: terraform
-  version: 0.12.30
-  source: https://github.com/hashicorp/terraform/archive/v0.12.30.zip  
+  version: 0.12.31
+  source: https://github.com/hashicorp/terraform/archive/v0.12.31.zip  
 - name: terraform-provider-aws
   version: 3.61.0
-  source: https://releases.hashicorp.com/terraform-provider-aws/2.67.0/terraform-provider-aws_2.67.0_linux_amd64.zip
+  source: https://releases.hashicorp.com/terraform-provider-aws/3.61.0/terraform-provider-aws_3.61.0_linux_amd64.zip
 - name: terraform-provider-helm
-  version: 1.2.0
-  source: https://releases.hashicorp.com/terraform-provider-helm/1.2.0/terraform-provider-helm_1.2.0_linux_amd64.zip
+  version: 2.3.0
+  source: https://releases.hashicorp.com/terraform-provider-helm/2.3.0/terraform-provider-helm_2.3.0_linux_amd64.zip
 - name: terraform-provider-kubernetes
-  version: 1.13.3
-  source: https://releases.hashicorp.com/terraform-provider-kubernetes/1.13.3/terraform-provider-kubernetes_1.13.3_linux_amd64.zip
+  version: 2.5.0
+  source: https://releases.hashicorp.com/terraform-provider-kubernetes/2.5.0/terraform-provider-kubernetes_2.5.0_linux_amd64.zip
 - name: terraform-provider-local
   version: 2.1.0
   source: https://releases.hashicorp.com/terraform-provider-local/2.1.0/terraform-provider-local_2.1.0_linux_amd64.zip
@@ -32,8 +32,8 @@ terraform_binaries:
   version: 2.2.0
   source: https://releases.hashicorp.com/terraform-provider-template/2.2.0/terraform-provider-template_2.2.0_linux_amd64.zip
 - name: terraform-provider-time
-  version: 0.7.0
-  source: https://releases.hashicorp.com/terraform-provider-time/0.7.0/terraform-provider-time_0.7.0_linux_amd64.zip
+  version: 0.7.2
+  source: https://releases.hashicorp.com/terraform-provider-time/0.7.2/terraform-provider-time_0.7.2_linux_amd64.zip
 - name: terraform-provider-tls
   version: 3.1.0
   source: https://releases.hashicorp.com/terraform-provider-tls/3.1.0/terraform-provider-tls_3.1.0_linux_amd64.zip

--- a/terraform/bind/providers.tf
+++ b/terraform/bind/providers.tf
@@ -1,8 +1,9 @@
 provider "kubernetes" {
-  version                = "~> 1.13.3"
+  version = "~>2.5"
+
   host                   = data.aws_eks_cluster.main.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
-  load_config_file       = false
+  token                  = data.aws_eks_cluster_auth.main.token
   exec {
     api_version = "client.authentication.k8s.io/v1alpha1"
     args        = ["token", "--cluster-id", data.aws_eks_cluster.main.id]

--- a/terraform/provision/Dockerfile
+++ b/terraform/provision/Dockerfile
@@ -8,4 +8,3 @@ RUN apk update
 RUN apk add --update git 
 
 ENTRYPOINT ["/bin/sh"]
-CMD ["-help"]

--- a/terraform/provision/Dockerfile
+++ b/terraform/provision/Dockerfile
@@ -1,0 +1,11 @@
+FROM hashicorp/terraform:0.12.31 as terraform
+
+FROM alpine/k8s:1.20.7
+
+COPY --from=terraform /bin/terraform /bin/terraform 
+
+RUN apk update
+RUN apk add --update git 
+
+ENTRYPOINT ["/bin/sh"]
+CMD ["-help"]

--- a/terraform/provision/README.md
+++ b/terraform/provision/README.md
@@ -1,8 +1,28 @@
-This directory exists to make it easier to test Terraform code in isolation from
-the broker. 
+# How to iterate on the provisioning code
 
-To test the code, run: 
-```
+You can develop and test the Terraform code for provisoining isolated from the
+broker context here.
+
+Set these three environment variables:
+
+- AWS_ACCESS_KEY_ID
+- AWS_SECRET_ACCESS_KEY
+- AWS_DEFAULT_REGION
+
+In order to have a development environment consistent with other collaborators,
+we use a special Docker image with the exact CLI binaries we want for testing,
+like so:
+
+```bash
+$ docker build -t eks-provision:latest .
+$ docker run -v `pwd`:`pwd` -w `pwd` --user $(id -u):$(id -g) -it --rm -e HOME=`pwd` -e TERM -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION --entrypoint /bin/sh eks-provision:latest
+
+[within the container]
 terraform init
-terraform apply
+terraform apply -auto-approve
+[tinker in your editor, run terraform apply, repeat]
+terraform destroy -auto-approve
+exit
 ```
+
+Doing so will avoid [discrepancies we've noted between development under OS X and W10](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1262#issuecomment-932792757).

--- a/terraform/provision/README.md
+++ b/terraform/provision/README.md
@@ -15,7 +15,7 @@ the broker context here.
 1. In order to have a development environment consistent with other
    collaborators, we use a special Docker image with the exact CLI binaries we
    want for testing. Doing so will avoid [discrepancies we've noted between development under OS X and W10](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1262#issuecomment-932792757).
-   
+
    First, build the image:
 
     ```bash
@@ -32,9 +32,16 @@ the broker context here.
     [within the container]
     terraform init
     terraform apply -auto-approve
-    [tinker in your editor, run terraform apply, repeat]
+    [tinker in your editor, run terraform apply, inspect the cluster, repeat]
     terraform destroy -auto-approve
     exit
     ```
 
+To interact with the cluster, use the local kubeconfig file generated during apply. For example:
 
+```bash
+export KUBECONFIG=kubeconfig_[hashedname]
+kubectl get all -A
+```
+
+(If you don't see the kubeconfig file, check that `write_kubeconfig=true` in `terraform.tfvars`.)

--- a/terraform/provision/README.md
+++ b/terraform/provision/README.md
@@ -1,28 +1,40 @@
 # How to iterate on the provisioning code
 
-You can develop and test the Terraform code for provisoining isolated from the
-broker context here.
+You can develop and test the Terraform code for provisioning in isolation from
+the broker context here.
 
-Set these three environment variables:
+1. Copy `terraform.tfvars-template` to `terraform.tfvars`, then edit the content
+   appropriately. In particular, customize the `instance` and `subdomain`
+   parameters to avoid collisions in the target AWS account!
+1. Set these three environment variables:
 
-- AWS_ACCESS_KEY_ID
-- AWS_SECRET_ACCESS_KEY
-- AWS_DEFAULT_REGION
+    - AWS_ACCESS_KEY_ID
+    - AWS_SECRET_ACCESS_KEY
+    - AWS_DEFAULT_REGION
 
-In order to have a development environment consistent with other collaborators,
-we use a special Docker image with the exact CLI binaries we want for testing,
-like so:
+1. In order to have a development environment consistent with other
+   collaborators, we use a special Docker image with the exact CLI binaries we
+   want for testing. Doing so will avoid [discrepancies we've noted between development under OS X and W10](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1262#issuecomment-932792757).
+   
+   First, build the image:
 
-```bash
-$ docker build -t eks-provision:latest .
-$ docker run -v `pwd`:`pwd` -w `pwd` --user $(id -u):$(id -g) -it --rm -e HOME=`pwd` -e TERM -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION --entrypoint /bin/sh eks-provision:latest
+    ```bash
+    docker build -t eks-provision:latest .
+    ```
 
-[within the container]
-terraform init
-terraform apply -auto-approve
-[tinker in your editor, run terraform apply, repeat]
-terraform destroy -auto-approve
-exit
-```
+1. Then, start a shell inside a container based on this image. The parameters
+   here carry some of your environment variables into that shell, and ensure
+   that you'll have permission to remove any files that get created.
 
-Doing so will avoid [discrepancies we've noted between development under OS X and W10](https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1262#issuecomment-932792757).
+    ```bash
+    $ docker run -v `pwd`:`pwd` -w `pwd` -e HOME=`pwd` --user $(id -u):$(id -g) -e TERM -it --rm -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_DEFAULT_REGION eks-provision:latest
+
+    [within the container]
+    terraform init
+    terraform apply -auto-approve
+    [tinker in your editor, run terraform apply, repeat]
+    terraform destroy -auto-approve
+    exit
+    ```
+
+

--- a/terraform/provision/crds.tf
+++ b/terraform/provision/crds.tf
@@ -11,7 +11,7 @@ resource "helm_release" "zookeeper-operator" {
   atomic          = "true"
   depends_on = [
     module.vpc,
-    aws_eks_fargate_profile.default_namespaces,
+    null_resource.cluster_functional,
   ]
 }
 
@@ -23,12 +23,8 @@ resource "helm_release" "solr-operator" {
   namespace       = "kube-system"
   cleanup_on_fail = "true"
   atomic          = "true"
-
-  # We need to wait until the zookeeper-operator is live
-  # This should sidestep the issue described here:
-  # https://github.com/bloomberg/solr-operator/issues/122
   depends_on = [
-    helm_release.zookeeper-operator
+    null_resource.cluster_functional
   ]
 }
 

--- a/terraform/provision/crds.tf
+++ b/terraform/provision/crds.tf
@@ -1,30 +1,19 @@
 # --------------------------------------------------------------------------
-# Install Solr and Zookeeper operators so that the CRDs will be available 
+# Install Solr operator so that the included Solr CRDs will be available 
 # --------------------------------------------------------------------------
-resource "helm_release" "zookeeper-operator" {
-  name            = "zookeeper"
-  chart           = "zookeeper-operator"
-  repository      = "https://charts.pravega.io/"
-  version         = "0.2.9"
-  namespace       = "kube-system"
-  cleanup_on_fail = "true"
-  atomic          = "true"
-  depends_on = [
-    module.vpc,
-    null_resource.cluster_functional,
-  ]
-}
 
+# TODO: Figure out how we can non-destructively update the CRDs from the
+# upstream manifest without uninstalling/reinstalling the operator
 resource "helm_release" "solr-operator" {
   name            = "solr"
   chart           = "solr-operator"
   repository      = "https://solr.apache.org/charts"
-  version         = "0.2.8"
+  version         = "0.4.0"
   namespace       = "kube-system"
   cleanup_on_fail = "true"
   atomic          = "true"
   depends_on = [
-    null_resource.cluster_functional
+    null_resource.cluster-functional
   ]
 }
 

--- a/terraform/provision/crds.tf
+++ b/terraform/provision/crds.tf
@@ -31,7 +31,7 @@ resource "helm_release" "solr-operator" {
   namespace       = "kube-system"
   cleanup_on_fail = "true"
   atomic          = "true"
-  
+
   set {
     name  = "zookeeper-operator.install"
     value = "false"
@@ -40,7 +40,7 @@ resource "helm_release" "solr-operator" {
     name  = "zookeeper-operator.use"
     value = "true"
   }
-  
+
   depends_on = [
     helm_release.zookeeper-operator
   ]

--- a/terraform/provision/crds.tf
+++ b/terraform/provision/crds.tf
@@ -1,9 +1,28 @@
-# --------------------------------------------------------------------------
-# Install Solr operator so that the included Solr CRDs will be available 
-# --------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# Install Solr operator and Zookeper operators so that their included CRDs will
+# be available to cluster users.
+# -----------------------------------------------------------------------------
+
+# We install the zookeeper-operator directly rather than letting the
+# solr-operator do it so that it will register its CRDs as part of the helm
+# install process.
+resource "helm_release" "zookeeper-operator" {
+  name            = "zookeeper"
+  chart           = "zookeeper-operator"
+  repository      = "https://charts.pravega.io/"
+  version         = "0.2.12"
+  namespace       = "kube-system"
+  cleanup_on_fail = "true"
+  atomic          = "true"
+  depends_on = [
+    null_resource.cluster-functional,
+  ]
+}
 
 # TODO: Figure out how we can non-destructively update the CRDs from the
-# upstream manifest without uninstalling/reinstalling the operator
+# upstream manifest without uninstalling/reinstalling the operator. We might be
+# able do this with a null_resource that triggers on the content of the upstream
+# CRD manifest file changing.
 resource "helm_release" "solr-operator" {
   name            = "solr"
   chart           = "solr-operator"
@@ -12,8 +31,18 @@ resource "helm_release" "solr-operator" {
   namespace       = "kube-system"
   cleanup_on_fail = "true"
   atomic          = "true"
+  
+  set {
+    name  = "zookeeper-operator.install"
+    value = "false"
+  }
+  set {
+    name  = "zookeeper-operator.use"
+    value = "true"
+  }
+  
   depends_on = [
-    null_resource.cluster-functional
+    helm_release.zookeeper-operator
   ]
 }
 

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -18,7 +18,7 @@ module "eks" {
   cluster_enabled_log_types     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
   cluster_log_retention_in_days = 180
   manage_aws_auth               = false
-  write_kubeconfig              = false
+  write_kubeconfig              = var.write_kubeconfig
   tags                          = merge(var.labels, { "domain" = local.domain })
   iam_path                      = "/${replace(local.cluster_name, "-", "")}/"
   fargate_profiles = {

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -9,29 +9,78 @@ module "eks" {
   # module versions above 14.0.0 do not work with Terraform 0.12, so we're stuck
   # on that version until the cloud-service-broker can use newer versions of
   # Terraform.
-  version                       = "~>14.0"
-  cluster_name                  = local.cluster_name
-  cluster_version               = local.cluster_version
-  vpc_id                        = module.vpc.aws_vpc_id
-  subnets                       = module.vpc.aws_subnet_private_prod_ids
-  cluster_enabled_log_types     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
-  cluster_log_retention_in_days = 180
-  manage_aws_auth               = false
-  write_kubeconfig              = var.write_kubeconfig
-  tags                          = merge(var.labels, { "domain" = local.domain })
-  iam_path                      = "/${replace(local.cluster_name, "-", "")}/"
-  fargate_profiles = {
-    default = {
-      name = "default"
-      namespace = "default"
-    }
-    kubesystem = {
-      name = "kube-system"
-      namespace = "kube-system"
-    }
-  }
+  version                         = "~>14.0"
+  cluster_name                    = local.cluster_name
+  cluster_version                 = local.cluster_version
+  vpc_id                          = module.vpc.aws_vpc_id
+  subnets                         = module.vpc.aws_subnet_private_prod_ids
+  cluster_enabled_log_types       = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+  cluster_log_retention_in_days   = 180
+  manage_aws_auth                 = false
+  write_kubeconfig                = var.write_kubeconfig
+  tags                            = merge(var.labels, { "domain" = local.domain })
+  iam_path                        = "/${replace(local.cluster_name, "-", "")}/"
+  create_fargate_pod_execution_role = false
+  # fargate_pod_execution_role_name = aws_iam_role.iam_role_fargate.name
+  # fargate_profiles = {
+  #   default = {
+  #     name      = "default"
+  #     namespace = "default"
+  #   }
+  #   kubesystem = {
+  #     name      = "kube-system"
+  #     namespace = "kube-system"
+  #   }
+  # }
 }
 
+resource "aws_iam_role" "iam_role_fargate" {
+  name = "eks-fargate-profile-${local.cluster_name}"
+  tags = var.labels
+  assume_role_policy = jsonencode({
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "eks-fargate-pods.amazonaws.com"
+      }
+    }]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonEKSFargatePodExecutionRolePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSFargatePodExecutionRolePolicy"
+  role       = aws_iam_role.iam_role_fargate.name
+}
+
+
+# We create Fargate profile(s) that select the requested
+# namespace(s). Fargate profiles are expensive to create and destroy, and there
+# can only be one create or destroy operation in flight at a time. So we want to
+# create as few as possible, and do it sequentially rather than in parallel.
+resource "aws_eks_fargate_profile" "default_namespaces" {
+  cluster_name           = data.aws_eks_cluster.main.name
+  fargate_profile_name   = "default-namespaces-${local.cluster_name}"
+  pod_execution_role_arn = aws_iam_role.iam_role_fargate.arn
+  subnet_ids             = module.vpc.aws_subnet_private_prod_ids
+  tags                   = var.labels
+  timeouts {
+    # For reasons unknown, Fargate profiles can take upward of 20 minutes to
+    # delete! I've never seen them go past 30m, though, so this seems OK.
+    delete = "30m"
+  }
+  selector {
+    namespace = "default"
+  }
+  selector {
+    namespace = "kube-system"
+  }
+
+  # This depends_on ensures that this resource is not provisioned until the
+  # cluster's kube API is available.
+  depends_on = [module.eks.cluster_id]
+}
 
 # Per AWS docs, for a Fargate-only cluster, you have to patch the coredns
 # deployment to remove the constraint that it wants to run on ec2, then restart
@@ -58,13 +107,12 @@ resource "null_resource" "cluster-functional" {
       kubectl --kubeconfig <(echo $KUBECONFIG | base64 -d) rollout status -n kube-system deployment coredns
     EOF
   }
-
-  # This depends_on ensures that this resource is not provisioned until the
-  # cluster's kube API is available, and not until we've verified that
-  # prerequisite binaries are available.
+  # This depends_on ensures that coredns will not be patched and restarted until the
+  # FargateProfile is in place, we've verified that prerequisite
+  # binaries are available.
   depends_on = [
     null_resource.prerequisite_binaries_present,
-    module.eks.cluster_id
+    aws_eks_fargate_profile.default_namespaces,
   ]
 }
 

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -60,7 +60,7 @@ resource "aws_iam_role_policy_attachment" "AmazonEKSFargatePodExecutionRolePolic
 # can only be one create or destroy operation in flight at a time. So we want to
 # create as few as possible, and do it sequentially rather than in parallel.
 resource "aws_eks_fargate_profile" "default_namespaces" {
-  cluster_name           = data.aws_eks_cluster.main.name
+  cluster_name           = local.cluster_name
   fargate_profile_name   = "default-namespaces-${local.cluster_name}"
   pod_execution_role_arn = aws_iam_role.iam_role_fargate.arn
   subnet_ids             = module.vpc.aws_subnet_private_prod_ids

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -1,5 +1,7 @@
 locals {
-  cluster_name    = "k8s-${substr(sha256(var.instance_name), 0, 16)}"
+  # Prevent provisioning if the necessary CLI binaries aren't present
+  binaries_present = null_resource.prerequisite_binaries_present.id != 0 ? true : false
+  cluster_name    = "k8s-${local.binaries_present ? substr(sha256(var.instance_name), 0, 16) : "failed"}"
   cluster_version = "1.19"
 }
 

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -1,7 +1,7 @@
 locals {
   # Prevent provisioning if the necessary CLI binaries aren't present
-  cluster_name     = "k8s-${substr(sha256(var.instance_name), 0, 16)}"
-  cluster_version  = "1.19"
+  cluster_name    = "k8s-${substr(sha256(var.instance_name), 0, 16)}"
+  cluster_version = "1.19"
 }
 
 module "eks" {
@@ -9,17 +9,17 @@ module "eks" {
   # module versions above 14.0.0 do not work with Terraform 0.12, so we're stuck
   # on that version until the cloud-service-broker can use newer versions of
   # Terraform.
-  version                         = "~>14.0"
-  cluster_name                    = local.cluster_name
-  cluster_version                 = local.cluster_version
-  vpc_id                          = module.vpc.aws_vpc_id
-  subnets                         = module.vpc.aws_subnet_private_prod_ids
-  cluster_enabled_log_types       = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
-  cluster_log_retention_in_days   = 180
-  manage_aws_auth                 = false
-  write_kubeconfig                = var.write_kubeconfig
-  tags                            = merge(var.labels, { "domain" = local.domain })
-  iam_path                        = "/${replace(local.cluster_name, "-", "")}/"
+  version                           = "~>14.0"
+  cluster_name                      = local.cluster_name
+  cluster_version                   = local.cluster_version
+  vpc_id                            = module.vpc.aws_vpc_id
+  subnets                           = module.vpc.aws_subnet_private_prod_ids
+  cluster_enabled_log_types         = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+  cluster_log_retention_in_days     = 180
+  manage_aws_auth                   = false
+  write_kubeconfig                  = var.write_kubeconfig
+  tags                              = merge(var.labels, { "domain" = local.domain })
+  iam_path                          = "/${replace(local.cluster_name, "-", "")}/"
   create_fargate_pod_execution_role = false
   # fargate_pod_execution_role_name = aws_iam_role.iam_role_fargate.name
   # fargate_profiles = {

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -5,9 +5,10 @@ locals {
 
 module "eks" {
   source = "terraform-aws-modules/eks/aws"
-  # version         = "13.2.1"
-  # eks 13.2.1 has dependency for aws provider 3.16.0 so moving eks version to 12.1.0
-  version                       = "12.1.0"
+  # module versions above 14.0.0 do not work with Terraform 0.12, so we're stuck
+  # on that version until the cloud-service-broker can use newer versions of
+  # Terraform.
+  version                       = "~>14.0"
   cluster_name                  = local.cluster_name
   cluster_version               = local.cluster_version
   vpc_id                        = module.vpc.aws_vpc_id

--- a/terraform/provision/eks.tf
+++ b/terraform/provision/eks.tf
@@ -1,8 +1,7 @@
 locals {
   # Prevent provisioning if the necessary CLI binaries aren't present
-  binaries_present = null_resource.prerequisite_binaries_present.id != 0 ? true : false
-  cluster_name    = "k8s-${local.binaries_present ? substr(sha256(var.instance_name), 0, 16) : "failed"}"
-  cluster_version = "1.19"
+  cluster_name     = "k8s-${substr(sha256(var.instance_name), 0, 16)}"
+  cluster_version  = "1.19"
 }
 
 module "eks" {

--- a/terraform/provision/external-dns.tf
+++ b/terraform/provision/external-dns.tf
@@ -72,7 +72,7 @@ resource "kubernetes_service_account" "external_dns" {
   }
   automount_service_account_token = true
   depends_on = [
-    aws_eks_fargate_profile.default_namespaces
+    null_resource.cluster-functional,
   ]
 }
 
@@ -97,7 +97,7 @@ resource "kubernetes_cluster_role" "external_dns" {
     verbs      = ["get", "list", "watch"]
   }
   depends_on = [
-    aws_eks_fargate_profile.default_namespaces
+    null_resource.cluster-functional,
   ]
 }
 
@@ -116,7 +116,7 @@ resource "kubernetes_cluster_role_binding" "external_dns" {
     namespace = kubernetes_service_account.external_dns.metadata.0.namespace
   }
   depends_on = [
-    aws_eks_fargate_profile.default_namespaces
+    null_resource.cluster-functional,
   ]
 }
 
@@ -151,6 +151,6 @@ resource "helm_release" "external_dns" {
     }
   }
   depends_on = [
-    aws_eks_fargate_profile.default_namespaces
+    null_resource.cluster-functional,
   ]
 }

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -18,7 +18,7 @@ resource "aws_iam_openid_connect_provider" "cluster" {
 # Use a convenient module to install the AWS Load Balancer controller
 module "aws_load_balancer_controller" {
   # source                    = "/local/path/to/terraform-kubernetes-aws-load-balancer-controller"
-  source           = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=v4.2.0gsa"
+  source           = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=v4.3.0gsa"
   k8s_cluster_type = "eks"
   k8s_namespace    = "kube-system"
   aws_region_name  = data.aws_region.current.name

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -258,10 +258,10 @@ resource "aws_acm_certificate" "cert" {
 
 # Validate the certificate using DNS method
 resource "aws_route53_record" "cert_validation" {
-  name    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.cert.domain_validation_options.0.resource_record_type
+  name    = tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_type
   zone_id = aws_route53_zone.cluster.id
-  records = [aws_acm_certificate.cert.domain_validation_options.0.resource_record_value]
+  records = [tolist(aws_acm_certificate.cert.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -23,7 +23,10 @@ module "aws_load_balancer_controller" {
   k8s_namespace             = "kube-system"
   aws_region_name           = data.aws_region.current.name
   k8s_cluster_name          = data.aws_eks_cluster.main.name
-  alb_controller_depends_on = [module.vpc, aws_eks_fargate_profile.default_namespaces, null_resource.namespace_fargate_logging]
+  alb_controller_depends_on = [
+    module.vpc,
+    null_resource.cluster-functional,
+  ]
   aws_tags                  = merge(var.labels, { "domain" = local.domain })
 }
 
@@ -86,15 +89,8 @@ resource "helm_release" "ingress_nginx" {
         allowPrivilegeEscalation: false
     VALUES
   ]
-  # provisioner "local-exec" {
-  #   interpreter = ["/bin/bash", "-c"]
-  #   environment = {
-  #     KUBECONFIG = base64encode(module.eks.kubeconfig)
-  #   }
-  #   command = "helm --kubeconfig <(echo $KUBECONFIG | base64 -d) test --logs -n ${self.namespace} ${self.name}"
-  # }
   depends_on = [
-    aws_eks_fargate_profile.default_namespaces
+    null_resource.cluster-functional,
   ]
 }
 

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -18,16 +18,16 @@ resource "aws_iam_openid_connect_provider" "cluster" {
 # Use a convenient module to install the AWS Load Balancer controller
 module "aws_load_balancer_controller" {
   # source                    = "/local/path/to/terraform-kubernetes-aws-load-balancer-controller"
-  source                    = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=v4.2.0gsa"
-  k8s_cluster_type          = "eks"
-  k8s_namespace             = "kube-system"
-  aws_region_name           = data.aws_region.current.name
-  k8s_cluster_name          = data.aws_eks_cluster.main.name
+  source           = "github.com/GSA/terraform-kubernetes-aws-load-balancer-controller.git?ref=v4.2.0gsa"
+  k8s_cluster_type = "eks"
+  k8s_namespace    = "kube-system"
+  aws_region_name  = data.aws_region.current.name
+  k8s_cluster_name = data.aws_eks_cluster.main.name
   alb_controller_depends_on = [
     module.vpc,
     null_resource.cluster-functional,
   ]
-  aws_tags                  = merge(var.labels, { "domain" = local.domain })
+  aws_tags = merge(var.labels, { "domain" = local.domain })
 }
 
 # ---------------------------------------------------------

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -276,7 +276,7 @@ resource "aws_route53_record" "www" {
   type    = "A"
 
   alias {
-    name                   = kubernetes_ingress.alb_to_nginx.load_balancer_ingress.0.hostname
+    name                   = kubernetes_ingress.alb_to_nginx.status[0].load_balancer[0].ingress[0].hostname
     zone_id                = data.aws_elb_hosted_zone_id.elb_zone_id.id
     evaluate_target_health = true
   }

--- a/terraform/provision/ingress.tf
+++ b/terraform/provision/ingress.tf
@@ -34,7 +34,7 @@ resource "helm_release" "ingress_nginx" {
   name       = "ingress-nginx"
   chart      = "ingress-nginx"
   repository = "https://kubernetes.github.io/ingress-nginx"
-  version    = "3.32.0"
+  version    = "3.37.0"
 
   namespace       = "kube-system"
   cleanup_on_fail = "true"

--- a/terraform/provision/logging.tf
+++ b/terraform/provision/logging.tf
@@ -1,29 +1,29 @@
 # -----------------------------------------------------------------------------------
 # Fargate Logging Policy and Policy Attachment for the existing Fargate pod execution IAM role
 # -----------------------------------------------------------------------------------
-# resource "aws_iam_policy" "AmazonEKSFargateLoggingPolicy" {
-#   name   = "AmazonEKSFargateLoggingPolicy-${local.cluster_name}"
-#   policy = <<-EOF
-#   {
-#     "Version": "2012-10-17",
-#     "Statement": [{
-#       "Effect": "Allow",
-#       "Action": [
-#         "logs:CreateLogStream",
-#         "logs:CreateLogGroup",
-#         "logs:DescribeLogStreams",
-#         "logs:PutLogEvents"
-#       ],
-#       "Resource": "*"
-#     }]
-#   }
-#   EOF
-# }
+resource "aws_iam_policy" "AmazonEKSFargateLoggingPolicy" {
+  name   = "AmazonEKSFargateLoggingPolicy-${local.cluster_name}"
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:CreateLogGroup",
+        "logs:DescribeLogStreams",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }]
+  }
+  EOF
+}
 
-# resource "aws_iam_role_policy_attachment" "AmazonEKSFargateLoggingPolicy" {
-#   policy_arn = aws_iam_policy.AmazonEKSFargateLoggingPolicy.arn
-#   role       = aws_iam_role.iam_role_fargate.name
-# }
+resource "aws_iam_role_policy_attachment" "AmazonEKSFargateLoggingPolicy" {
+  policy_arn = aws_iam_policy.AmazonEKSFargateLoggingPolicy.arn
+  role       = aws_iam_role.iam_role_fargate.name
+}
 
 # ---------------------------------------------------------------------------------------------
 # Fargate logging by fluentbit requires namespace aws-observability and Configmap
@@ -31,43 +31,43 @@
 
 # Configure Kubernetes namespace aws-observability by adding the aws-observability annotation. This
 # annotation is supported in terraform 0.13 or higher. So kubectl is used to provision the namespace.
-# data "template_file" "logging" {
-#   template = <<-EOF
-# kind: Namespace
-# apiVersion: v1
-# metadata:
-#   name: aws-observability
-#   labels:
-#     aws-observability: enabled
-# ---
-# kind: ConfigMap
-# apiVersion: v1
-# metadata:
-#   name: aws-logging
-#   namespace: aws-observability
-# data:
-#   output.conf: |
-#     [OUTPUT]
-#         Name cloudwatch_logs
-#         Match   *
-#         region ${local.region}
-#         log_group_name fluent-bit-cloudwatch-${local.cluster_name}
-#         log_stream_prefix from-fluent-bit-
-#         auto_create_group On
-# EOF
-# }
+data "template_file" "logging" {
+  template = <<-EOF
+    kind: Namespace
+    apiVersion: v1
+    metadata:
+      name: aws-observability
+      labels:
+        aws-observability: enabled
+    ---
+    kind: ConfigMap
+    apiVersion: v1
+    metadata:
+      name: aws-logging
+      namespace: aws-observability
+    data:
+      output.conf: |
+        [OUTPUT]
+          Name cloudwatch_logs
+          Match   *
+          region ${local.region}
+          log_group_name fluent-bit-cloudwatch-${local.cluster_name}
+          log_stream_prefix from-fluent-bit-
+          auto_create_group On
+  EOF
+}
 
-# resource "null_resource" "namespace_fargate_logging" {
-#   provisioner "local-exec" {
-#     interpreter = ["/bin/bash", "-c"]
-#     environment = {
-#       KUBECONFIG = base64encode(module.eks.kubeconfig)
-#     }
-#     command = <<-EOF
-#       kubectl --kubeconfig <(echo $KUBECONFIG | base64 -d) apply -f <(echo '${data.template_file.logging.rendered}') 
-#     EOF
-#   }
-#   depends_on = [
-#     null_resource.cluster-functional,
-#   ]
-# }
+resource "null_resource" "namespace_fargate_logging" {
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      KUBECONFIG = base64encode(module.eks.kubeconfig)
+    }
+    command = <<-EOF
+      kubectl --kubeconfig <(echo $KUBECONFIG | base64 -d) apply -f <(echo '${data.template_file.logging.rendered}') 
+    EOF
+  }
+  depends_on = [
+    null_resource.cluster-functional,
+  ]
+}

--- a/terraform/provision/logging.tf
+++ b/terraform/provision/logging.tf
@@ -1,29 +1,29 @@
 # -----------------------------------------------------------------------------------
 # Fargate Logging Policy and Policy Attachment for the existing Fargate pod execution IAM role
 # -----------------------------------------------------------------------------------
-resource "aws_iam_policy" "AmazonEKSFargateLoggingPolicy" {
-  name   = "AmazonEKSFargateLoggingPolicy-${local.cluster_name}"
-  policy = <<-EOF
-  {
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogStream",
-        "logs:CreateLogGroup",
-        "logs:DescribeLogStreams",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "*"
-    }]
-  }
-  EOF
-}
+# resource "aws_iam_policy" "AmazonEKSFargateLoggingPolicy" {
+#   name   = "AmazonEKSFargateLoggingPolicy-${local.cluster_name}"
+#   policy = <<-EOF
+#   {
+#     "Version": "2012-10-17",
+#     "Statement": [{
+#       "Effect": "Allow",
+#       "Action": [
+#         "logs:CreateLogStream",
+#         "logs:CreateLogGroup",
+#         "logs:DescribeLogStreams",
+#         "logs:PutLogEvents"
+#       ],
+#       "Resource": "*"
+#     }]
+#   }
+#   EOF
+# }
 
-resource "aws_iam_role_policy_attachment" "AmazonEKSFargateLoggingPolicy" {
-  policy_arn = aws_iam_policy.AmazonEKSFargateLoggingPolicy.arn
-  role       = aws_iam_role.iam_role_fargate.name
-}
+# resource "aws_iam_role_policy_attachment" "AmazonEKSFargateLoggingPolicy" {
+#   policy_arn = aws_iam_policy.AmazonEKSFargateLoggingPolicy.arn
+#   role       = aws_iam_role.iam_role_fargate.name
+# }
 
 # ---------------------------------------------------------------------------------------------
 # Fargate logging by fluentbit requires namespace aws-observability and Configmap
@@ -31,43 +31,43 @@ resource "aws_iam_role_policy_attachment" "AmazonEKSFargateLoggingPolicy" {
 
 # Configure Kubernetes namespace aws-observability by adding the aws-observability annotation. This
 # annotation is supported in terraform 0.13 or higher. So kubectl is used to provision the namespace.
-data "template_file" "logging" {
-  template = <<-EOF
-kind: Namespace
-apiVersion: v1
-metadata:
-  name: aws-observability
-  labels:
-    aws-observability: enabled
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: aws-logging
-  namespace: aws-observability
-data:
-  output.conf: |
-    [OUTPUT]
-        Name cloudwatch_logs
-        Match   *
-        region ${local.region}
-        log_group_name fluent-bit-cloudwatch-${local.cluster_name}
-        log_stream_prefix from-fluent-bit-
-        auto_create_group On
-EOF
-}
+# data "template_file" "logging" {
+#   template = <<-EOF
+# kind: Namespace
+# apiVersion: v1
+# metadata:
+#   name: aws-observability
+#   labels:
+#     aws-observability: enabled
+# ---
+# kind: ConfigMap
+# apiVersion: v1
+# metadata:
+#   name: aws-logging
+#   namespace: aws-observability
+# data:
+#   output.conf: |
+#     [OUTPUT]
+#         Name cloudwatch_logs
+#         Match   *
+#         region ${local.region}
+#         log_group_name fluent-bit-cloudwatch-${local.cluster_name}
+#         log_stream_prefix from-fluent-bit-
+#         auto_create_group On
+# EOF
+# }
 
-resource "null_resource" "namespace_fargate_logging" {
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    environment = {
-      KUBECONFIG = base64encode(module.eks.kubeconfig)
-    }
-    command = <<-EOF
-      kubectl --kubeconfig <(echo $KUBECONFIG | base64 -d) apply -f <(echo '${data.template_file.logging.rendered}') 
-    EOF
-  }
-  depends_on = [
-    aws_eks_fargate_profile.default_namespaces
-  ]
-}
+# resource "null_resource" "namespace_fargate_logging" {
+#   provisioner "local-exec" {
+#     interpreter = ["/bin/bash", "-c"]
+#     environment = {
+#       KUBECONFIG = base64encode(module.eks.kubeconfig)
+#     }
+#     command = <<-EOF
+#       kubectl --kubeconfig <(echo $KUBECONFIG | base64 -d) apply -f <(echo '${data.template_file.logging.rendered}') 
+#     EOF
+#   }
+#   depends_on = [
+#     null_resource.cluster-functional,
+#   ]
+# }

--- a/terraform/provision/main.tf
+++ b/terraform/provision/main.tf
@@ -9,25 +9,17 @@
 #   https://medium.com/citihub/a-more-secure-way-to-call-kubectl-from-terraform-1052adf37af8
 
 # Confirm that the necessary CLI binaries are present
-resource "null_resource" "prerequisite_binaries_present" {
-  provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
-    command     = <<-EOF
-      which aws-iam-authenticator git helm kubectl
-    EOF
-  }
-}
-
+#
 # If the necessary CLI binaries are not present, then we'll only get partway
 # through provisioning before we are stopped cold as we try to use them,
 # leaving everything in a poor state. We want to check for them as early as we
-# can to avoid that. As this random_id is key to a bunch of other
-# provisioning, we add an explicit dependency here to ensure the check for the
-# binaries happens early.
-resource "random_id" "cluster" {
-  byte_length = 8
-
-  depends_on = [
-    null_resource.prerequisite_binaries_present
-  ]
+# can to avoid that. 
+resource "null_resource" "prerequisite_binaries_present" {
+  triggers = {
+    always_run = timestamp()
+  }  
+  provisioner "local-exec" {
+    interpreter = ["/bin/sh", "-c"]
+    command     = "which aws-iam-authenticator git helm kubectl"
+  }
 }

--- a/terraform/provision/main.tf
+++ b/terraform/provision/main.tf
@@ -15,9 +15,6 @@
 # leaving everything in a poor state. We want to check for them as early as we
 # can to avoid that. 
 resource "null_resource" "prerequisite_binaries_present" {
-  triggers = {
-    always_run = timestamp()
-  }  
   provisioner "local-exec" {
     interpreter = ["/bin/sh", "-c"]
     command     = "which aws-iam-authenticator git helm kubectl"

--- a/terraform/provision/providers.tf
+++ b/terraform/provision/providers.tf
@@ -8,30 +8,28 @@ provider "aws" {
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.main.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
-  load_config_file       = false
+  token                  = data.aws_eks_cluster_auth.main.token
+
   exec {
     api_version = "client.authentication.k8s.io/v1alpha1"
     args        = ["token", "--cluster-id", data.aws_eks_cluster.main.id]
     command     = "aws-iam-authenticator"
   }
-  version = "~> 1.13.3"
+  version = "~>2.5"
 }
 
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.main.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
-    load_config_file       = false
-    config_path            = "./kubeconfig_${module.eks.cluster_id}"
+    token                  = data.aws_eks_cluster_auth.main.token
     exec {
       api_version = "client.authentication.k8s.io/v1alpha1"
       args        = ["token", "--cluster-id", data.aws_eks_cluster.main.id]
       command     = "aws-iam-authenticator"
     }
   }
-  # Helm 2.0.1 seems to have issues with alias. When alias is removed the helm_release provider working
-  # Using Helm < 2.0.1 version seem to solve the issue.
-  # version = "~> 1.2"
-  version = "1.2.0"
+
+  version = "~>2.3"
 }
 

--- a/terraform/provision/providers.tf
+++ b/terraform/provision/providers.tf
@@ -1,10 +1,7 @@
 provider "aws" {
-  # We need at least 3.16.0 because it fixes a problem with creating/deleting
-  # Fargate profiles in parallel. See this issue for more information:
-  # https://github.com/hashicorp/terraform-provider-aws/issues/13372#issuecomment-729689441
-  # version = "~> 3.16.0"
-  # Using 2.67.0 so that Route53 that was developed using the eks cluster works with the Fargate
-  version = "~> 2.67.0"
+  # We need at least 3.31.0 because it was the first version to support DS
+  # records in aws_route53_record
+  version = "~> 3.31"
   region  = local.region
 }
 

--- a/terraform/provision/rbac.tf
+++ b/terraform/provision/rbac.tf
@@ -14,6 +14,6 @@ resource "kubernetes_role" "namespace_admin" {
   }
 
   depends_on = [
-    aws_eks_fargate_profile.default_namespaces
+    null_resource.cluster-functional,
   ]
 }

--- a/terraform/provision/terraform.tfvars-template
+++ b/terraform/provision/terraform.tfvars-template
@@ -2,3 +2,4 @@ region="us-west-2"          # region where the instance will be created
 zone="parent domain"        # pre-existing zone, created outside Terraform (eg ssb-dev.datagov.us)
 instance_name="my-instance" # a unique name to avoid collisions in AWS
 subdomain="my-subdomain"    # a unique subdomain name to avoid collisions in AWS
+write_kubeconfig = true     # generate a kubeconfig (only here for dev/test iteration)

--- a/terraform/provision/terraform.tfvars-template
+++ b/terraform/provision/terraform.tfvars-template
@@ -1,0 +1,4 @@
+region="us-west-2"          # region where the instance will be created
+zone="parent domain"        # pre-existing zone, created outside Terraform (eg ssb-dev.datagov.us)
+instance_name="my-instance" # a unique name to avoid collisions in AWS
+subdomain="my-subdomain"    # a unique subdomain name to avoid collisions in AWS

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -21,3 +21,8 @@ variable "zone" {
 variable "region" {
   type = string
 }
+
+variable "write_kubeconfig" {
+  type = bool
+  default = false
+}

--- a/terraform/provision/variables.tf
+++ b/terraform/provision/variables.tf
@@ -23,6 +23,6 @@ variable "region" {
 }
 
 variable "write_kubeconfig" {
-  type = bool
+  type    = bool
   default = false
 }

--- a/terraform/provision/vpc.tf
+++ b/terraform/provision/vpc.tf
@@ -17,7 +17,7 @@ module "vpc" {
   # See https://aws.amazon.com/premiumsupport/knowledge-center/eks-vpc-subnet-discovery/
   global_tags = merge(var.labels, {
     "kubernetes.io/cluster/${local.cluster_name}" = "shared",
-    "domain" = local.domain
+    "domain"                                      = local.domain
   })
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1


### PR DESCRIPTION
Added instructions for iterating in the terraform/provision directory
Added instructions for cleaning up a botched service instance in AWS

Upgraded all the Terraform stuff:
* terraform, by a few patchlevels
* the AWS  provider, helm provider, kubernetes provider
* the EKS module
* the nginx-ingress chart
* the alb-controller helm chart
* the solr-operator and zookeeper-operator
* the manifest file used by the broker itself
